### PR TITLE
auth_pam_x11: support font selection

### DIFF
--- a/helpers/auth_pam_x11.c
+++ b/helpers/auth_pam_x11.c
@@ -502,7 +502,7 @@ int main() {
 
   Black = BlackPixel(display, DefaultScreen(display));
   White = WhitePixel(display, DefaultScreen(display));
-  
+
   font = NULL;
   const char *font_name = getenv("XSECURELOCK_FONT");
   if (font_name != NULL && font_name[0] != 0) {
@@ -523,8 +523,9 @@ int main() {
   gcattrs.function = GXcopy;
   gcattrs.foreground = White;
   gcattrs.background = Black;
-  gc = XCreateGC(display, window, GCFunction | GCForeground | GCBackground,
-                 &gcattrs);
+  gcattrs.font = font->fid;
+  gc = XCreateGC(display, window,
+                 GCFunction | GCForeground | GCBackground | GCFont, &gcattrs);
   XSetWindowBackground(display, window, Black);
 
   struct pam_conv conv;

--- a/helpers/auth_pam_x11.c
+++ b/helpers/auth_pam_x11.c
@@ -502,7 +502,18 @@ int main() {
 
   Black = BlackPixel(display, DefaultScreen(display));
   White = WhitePixel(display, DefaultScreen(display));
-  font = XLoadQueryFont(display, "fixed");
+  
+  font = NULL;
+  const char *font_name = getenv("XSECURELOCK_FONT");
+  if (font_name != NULL && font_name[0] != 0) {
+    font = XLoadQueryFont(display, font_name);
+    if (font == NULL) {
+      fprintf(stderr, "could not load the specified font %s - trying to fall back to fixed\n", font_name);
+    }
+  }
+  if (font == NULL) {
+    font = XLoadQueryFont(display, "fixed");
+  }
   if (font == NULL) {
     fprintf(stderr, "could not load a mind-bogglingly stupid font\n");
     exit(1);


### PR DESCRIPTION
Usage:

- Find a good font name with xfontsel.
- Launch the screen saver via something like:

```
XSECURELOCK_FONT=-misc-fixed-medium-r-normal--20-200-75-75-c-100-iso10646-1 xsecurelock 
```

If the font can for some reason not be loaded, we're still falling back to fixed to allow SOME unlocking.