### PR TITLE
divVerent/xrandr - XRandR 1.2 and 1.5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 
 # Binaries.
 /auth_pam_x11
+/saver_multiplex
 /xsecurelock
 
 # Doxygen stuff.

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ xsecurelock_CPPFLAGS = \
 	-DHELPER_PATH=\"$(pkglibexecdir)\" \
 	-DDOCS_PATH=\"$(docdir)\" \
 	-DAUTH_EXECUTABLE=\"@auth_executable@\" \
+	-DGLOBAL_SAVER_EXECUTABLE=\"@global_saver_executable@\" \
 	-DSAVER_EXECUTABLE=\"@saver_executable@\"
 
 if HAVE_SCRNSAVER

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,8 @@ xsecurelock_SOURCES = \
 	env_settings.c env_settings.h \
 	saver_child.c saver_child.h \
 	mlock_page.h \
-	main.c
+	main.c \
+	xscreensaver_api.c xscreensaver_api.h
 xsecurelock_CPPFLAGS = \
 	-DHELPER_PATH=\"$(pkglibexecdir)\" \
 	-DDOCS_PATH=\"$(docdir)\" \
@@ -54,7 +55,8 @@ auth_pam_x11_SOURCES = \
 	helpers/auth_pam_x11.c \
 	env_settings.c env_settings.h \
 	helpers/monitors.c helpers/monitors.h \
-	mlock_page.h
+	mlock_page.h \
+	xscreensaver_api.c xscreensaver_api.h
 auth_pam_x11_CPPFLAGS = \
 	-DPAM_SERVICE_NAME=\"@pam_service_name@\"
 if PAM_CHECK_ACCOUNT_TYPE

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,8 +59,11 @@ saver_multiplex_SOURCES = \
 	xscreensaver_api.c xscreensaver_api.h
 saver_multiplex_CPPFLAGS = \
 	-DSAVER_EXECUTABLE=\"@saver_executable@\"
-if HAVE_XRANDR
-saver_multiplex_CPPFLAGS += -DHAVE_XRANDR
+if HAVE_XRANDR12
+saver_multiplex_CPPFLAGS += -DHAVE_XRANDR12
+endif
+if HAVE_XRANDR15
+saver_multiplex_CPPFLAGS += -DHAVE_XRANDR15
 endif
 
 if HAVE_PAM
@@ -81,8 +84,11 @@ endif
 if HAVE_XKB
 auth_pam_x11_CPPFLAGS += -DHAVE_XKB
 endif
-if HAVE_XRANDR
-auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR
+if HAVE_XRANDR12
+auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR12
+endif
+if HAVE_XRANDR15
+auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR15
 endif
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,22 @@ helpers_SCRIPTS = \
 	helpers/saver_mpv \
 	helpers/saver_xscreensaver
 
-if HAVE_PAM
 helpers_PROGRAMS = \
+	saver_multiplex
+saver_multiplex_SOURCES = \
+	helpers/saver_multiplex.c \
+	env_settings.c env_settings.h \
+	helpers/monitors.c helpers/monitors.h \
+	saver_child.c saver_child.h \
+	xscreensaver_api.c xscreensaver_api.h
+saver_multiplex_CPPFLAGS = \
+	-DSAVER_EXECUTABLE=\"@saver_executable@\"
+if HAVE_XRANDR
+saver_multiplex_CPPFLAGS += -DHAVE_XRANDR
+endif
+
+if HAVE_PAM
+helpers_PROGRAMS += \
 	auth_pam_x11
 auth_pam_x11_SOURCES = \
 	helpers/auth_pam_x11.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,8 @@ helpers_PROGRAMS = \
 	auth_pam_x11
 auth_pam_x11_SOURCES = \
 	helpers/auth_pam_x11.c \
+	helpers/monitors.c \
+	helpers/monitors.h \
 	mlock_page.h
 auth_pam_x11_CPPFLAGS = \
 	-DPAM_SERVICE_NAME=\"@pam_service_name@\"
@@ -60,6 +62,9 @@ auth_pam_x11_CPPFLAGS += \
 endif
 if HAVE_XKB
 auth_pam_x11_CPPFLAGS += -DHAVE_XKB
+endif
+if HAVE_XRANDR
+auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR
 endif
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,11 +59,8 @@ saver_multiplex_SOURCES = \
 	xscreensaver_api.c xscreensaver_api.h
 saver_multiplex_CPPFLAGS = \
 	-DSAVER_EXECUTABLE=\"@saver_executable@\"
-if HAVE_XRANDR12
-saver_multiplex_CPPFLAGS += -DHAVE_XRANDR12
-endif
-if HAVE_XRANDR15
-saver_multiplex_CPPFLAGS += -DHAVE_XRANDR15
+if HAVE_XRANDR
+saver_multiplex_CPPFLAGS += -DHAVE_XRANDR
 endif
 
 if HAVE_PAM
@@ -84,11 +81,8 @@ endif
 if HAVE_XKB
 auth_pam_x11_CPPFLAGS += -DHAVE_XKB
 endif
-if HAVE_XRANDR12
-auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR12
-endif
-if HAVE_XRANDR15
-auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR15
+if HAVE_XRANDR
+auth_pam_x11_CPPFLAGS += -DHAVE_XRANDR
 endif
 endif
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Options to XSecureLock can be passed by environment variables:
 * `XSECURELOCK_AUTH`: specifies the desired authentication module.
 * `XSECURELOCK_FONT`: X11 font name to use for auth_pam_x11. You can get a list
   of supported font names by running `xlsfonts`.
+* `XSECURELOCK_GLOBAL_SAVER`: specifies the desired global screen saver module
+  (by default this is a multiplexer that runs `XSECURELOCK_SAVER` on each
+  screen).
 * `XSECURELOCK_NO_COMPOSITE`: disables covering the composite overlay window.
   This switches to a more traditional way of locking, but may allow desktop
   notifications to be visible on top of the screen lock. Not recommended.
@@ -150,6 +153,8 @@ The following screen saver modules are included:
 * `saver_mplayer` and `saver_mpv`: Plays a video using mplayer or mpv,
   respectively. The video to play is selected at random among all files in
   `~/Videos`.
+* `saver_multiplex`: Watches the display configuration and runs another screen
+  saver module once on each screen; used internally.
 * `saver_xscreensaver`: Runs an XScreenSaver hack from an existing XScreenSaver
   setup.
 

--- a/auth_child.c
+++ b/auth_child.c
@@ -25,6 +25,7 @@ limitations under the License.
 #include <unistd.h>    // for close, pid_t, ssize_t, dup2, etc
 
 #include "env_settings.h"
+#include "xscreensaver_api.h"
 
 //! The PID of a currently running saver child, or 0 if none is running.
 static pid_t auth_child_pid = 0;
@@ -146,6 +147,7 @@ int WatchAuthChild(Display *dpy, Window w, const char *executable,
       } else if (pid == 0) {
         // Child process.
         setsid();
+        ExportWindowID(w);
         dup2(pc[0], 0);
         close(pc[0]);
         close(pc[1]);

--- a/auth_child.c
+++ b/auth_child.c
@@ -71,7 +71,7 @@ int WantAuthChild(int force_auth) {
  * \return 1 if buf contains at least one non-control character, and 0
  *   otherwise.
  */
-static int ContainsNonControl(const char* buf) {
+static int ContainsNonControl(const char *buf) {
   while (*buf) {
     // Note: this almost isprint but not quite - isprint returns false on
     // high bytes in UTF-8 locales but we do want to forward anything UTF-8.

--- a/auth_child.h
+++ b/auth_child.h
@@ -17,7 +17,8 @@ limitations under the License.
 #ifndef AUTH_CHILD_H
 #define AUTH_CHILD_H
 
-#include <X11/Xlib.h>
+#include <X11/X.h>     // for Window
+#include <X11/Xlib.h>  // for Display
 
 /*! \brief Checks whether an auth child should be running.
  *

--- a/configure.ac
+++ b/configure.ac
@@ -71,13 +71,11 @@ RP_SEARCH_LIBS(XkbGetIndicatorState, X11,
                [HAVE_XKB], [xkb], [check],
                [Use the X Keyboard extension to show the keyboard LEDs])
 
-AC_SEARCH_LIBS(XRRGetMonitors, Xrandr,
-               [have_xrandr15=true], [have_xrandr15=false])
-AM_CONDITIONAL([HAVE_XRANDR15], [test x$have_xrandr15 = xtrue])
-
-AC_SEARCH_LIBS(XRRGetScreenResources, Xrandr,
-               [have_xrandr12=true], [have_xrandr12=false])
-AM_CONDITIONAL([HAVE_XRANDR12], [test x$have_xrandr12 = xtrue])
+# XRandR provides information about monitor layouts and is strongly recommended
+# on systems which can use more than one monitor (which includes most laptops).
+RP_SEARCH_LIBS(XRRGetScreenResources, Xrandr,
+               [HAVE_XRANDR], [xrandr], [check],
+               [Use the XRandR extension to query monitor layouts])
 
 pam_service_name=
 enable_pam_check_account_type=no

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,10 @@ AC_SEARCH_LIBS(XkbGetIndicatorState, X11,
                [have_xkb=true], [have_xkb=false])
 AM_CONDITIONAL([HAVE_XKB], [test x$have_xkb = xtrue])
 
+AC_SEARCH_LIBS(XRRGetCrtcInfo, Xrandr,
+               [have_xrandr=true], [have_xrandr=false])
+AM_CONDITIONAL([HAVE_XRANDR], [test x$have_xrandr = xtrue])
+
 pam_service_name=
 enable_pam_check_account_type=no
 

--- a/configure.ac
+++ b/configure.ac
@@ -98,12 +98,22 @@ AC_ARG_WITH([default_auth_module],
 
 AC_MSG_NOTICE([Configured default auth module: $auth_executable])
 
+AC_ARG_WITH([default_global_saver_module],
+            AC_HELP_STRING([--with-default-global-saver-module],
+                           [The default global saver module to use when none was
+                            pecified. Can be overridden via the
+                            XSECURELOCK_GLOBAL_SAVER environment variable.]),
+                            [global_saver_executable=$withval],
+                            [global_saver_executable=saver_multiplex])
+
+AC_MSG_NOTICE([Configured default global saver module: ]dnl
+[$global_saver_executable])
+
 AC_ARG_WITH([default_saver_module],
             AC_HELP_STRING([--with-default-saver-module],
-                           [The default saver module to use when none wa
-                            pecified. Can be overridden via the
-                            XSECURELOCK_SAVER environment variable or a command
-                            line argument.]),
+                           [The default per-screen saver module to use when none
+                            was pecified. Can be overridden via the
+                            XSECURELOCK_SAVER environment variable.]),
                             [saver_executable=$withval],
                             [saver_executable=saver_blank])
 
@@ -111,6 +121,7 @@ AC_MSG_NOTICE([Configured default saver module: $saver_executable])
 
 AC_SUBST(pam_service_name)
 AC_SUBST(auth_executable)
+AC_SUBST(global_saver_executable)
 AC_SUBST(saver_executable)
 AM_CONDITIONAL([PAM_CHECK_ACCOUNT_TYPE],
                [test x$enable_pam_check_account_type = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -43,9 +43,13 @@ AC_SEARCH_LIBS(XkbGetIndicatorState, X11,
                [have_xkb=true], [have_xkb=false])
 AM_CONDITIONAL([HAVE_XKB], [test x$have_xkb = xtrue])
 
-AC_SEARCH_LIBS(XRRGetCrtcInfo, Xrandr,
-               [have_xrandr=true], [have_xrandr=false])
-AM_CONDITIONAL([HAVE_XRANDR], [test x$have_xrandr = xtrue])
+AC_SEARCH_LIBS(XRRGetMonitors, Xrandr,
+               [have_xrandr15=true], [have_xrandr15=false])
+AM_CONDITIONAL([HAVE_XRANDR15], [test x$have_xrandr15 = xtrue])
+
+AC_SEARCH_LIBS(XRRGetScreenResources, Xrandr,
+               [have_xrandr12=true], [have_xrandr12=false])
+AM_CONDITIONAL([HAVE_XRANDR12], [test x$have_xrandr12 = xtrue])
 
 pam_service_name=
 enable_pam_check_account_type=no

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends: debhelper (>= 8.0.0),
   libc6,
   libx11-dev,
   libxcomposite-dev,
+  libxrandr-dev,
   libxss-dev,
   x11proto-core-dev
 Standards-Version: 3.9.4

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,7 @@ override_dh_auto_configure:
 		--with-pam --with-pam-service-name=common-auth \
 		--with-xcomposite \
 		--with-xkb \
+		--with-xrandr \
 		--with-xss
 
 override_dh_autoreconf:

--- a/env_settings.c
+++ b/env_settings.c
@@ -16,10 +16,9 @@ limitations under the License.
 
 #include "env_settings.h"
 
-#include <errno.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <errno.h>   // for errno, ERANGE
+#include <stdio.h>   // for fprintf, NULL, stderr
+#include <stdlib.h>  // for getenv, strtol, strtoull
 
 unsigned long long GetUnsignedLongLongSetting(const char* name,
                                               unsigned long long def) {

--- a/env_settings.c
+++ b/env_settings.c
@@ -45,7 +45,7 @@ long GetLongSetting(const char* name, long def) {
   if (value == NULL || value[0] == 0) {
     return def;
   }
-  char *endptr = NULL;
+  char* endptr = NULL;
   errno = 0;
   long number = strtol(value, &endptr, 0);
   if (errno == ERANGE) {
@@ -61,15 +61,15 @@ long GetLongSetting(const char* name, long def) {
 
 int GetIntSetting(const char* name, int def) {
   long lnumber = GetLongSetting(name, def);
-  int number = (int) lnumber;
-  if (lnumber != (long) number) {
+  int number = (int)lnumber;
+  if (lnumber != (long)number) {
     fprintf(stderr, "Ignoring out-of-range value of %s: %d.", name, number);
     return def;
   }
   return number;
 }
 
-const char *GetStringSetting(const char* name, const char* def) {
+const char* GetStringSetting(const char* name, const char* def) {
   const char* value = getenv(name);
   if (value == NULL || value[0] == 0) {
     return def;

--- a/env_settings.h
+++ b/env_settings.h
@@ -48,6 +48,6 @@ int GetIntSetting(const char* name, int def);
  * \param def The default value.
  * \return The value of the setting, or def if unset or empty.
  */
-const char *GetStringSetting(const char* name, const char* def);
+const char* GetStringSetting(const char* name, const char* def);
 
 #endif

--- a/helpers/auth_pam_x11.c
+++ b/helpers/auth_pam_x11.c
@@ -29,13 +29,13 @@ limitations under the License.
 #include <unistd.h>                 // for gethostname, getuid, read, ssize_t
 
 #ifdef HAVE_XKB
-#include <X11/XKBlib.h>             // for XkbFreeClientMap, XkbGetIndicator...
+#include <X11/XKBlib.h>  // for XkbFreeClientMap, XkbGetIndicator...
 #endif
 
-#include "../env_settings.h"        // for GetStringSetting
-#include "../mlock_page.h"          // for MLOCK_PAGE
-#include "../xscreensaver_api.h"    // for ReadWindowID
-#include "monitors.h"               // for Monitor, GetMonitors, IsMonitorCh...
+#include "../env_settings.h"      // for GetStringSetting
+#include "../mlock_page.h"        // for MLOCK_PAGE
+#include "../xscreensaver_api.h"  // for ReadWindowID
+#include "monitors.h"             // for Monitor, GetMonitors, IsMonitorCh...
 
 //! The blinking interval in microseconds.
 #define BLINK_INTERVAL (250 * 1000)
@@ -134,8 +134,8 @@ const char *get_indicators() {
       continue;
     }
     memcpy(p, ", ", 2);
-    memcpy(p+2, word, n);
-    p += n+2;
+    memcpy(p + 2, word, n);
+    p += n + 2;
   }
   *p = 0;
   return buf;
@@ -157,7 +157,7 @@ void display_string(const char *title, const char *str) {
   static int region_h = 0;
 
   int th = font->max_bounds.ascent + font->max_bounds.descent + 4;
-  int to = font->max_bounds.ascent + 2; // Text at to has bbox from 0 to th.
+  int to = font->max_bounds.ascent + 2;  // Text at to has bbox from 0 to th.
 
   int len_title = strlen(title);
   int tw_title = XTextWidth(font, title, len_title);
@@ -187,15 +187,14 @@ void display_string(const char *title, const char *str) {
                  region_h, False);
     }
 
-    XDrawString(display, window, gc, cx - tw_title / 2,
-                sy, title, len_title);
+    XDrawString(display, window, gc, cx - tw_title / 2, sy, title, len_title);
 
-    XDrawString(display, window, gc, cx - tw_str / 2,
-                sy + th * 2, str, len_str);
+    XDrawString(display, window, gc, cx - tw_str / 2, sy + th * 2, str,
+                len_str);
 
 #ifdef HAVE_XKB
-    XDrawString(display, window, gc, cx - tw_indicators / 2,
-                sy + th * 3, indicators, len_indicators);
+    XDrawString(display, window, gc, cx - tw_indicators / 2, sy + th * 3,
+                indicators, len_indicators);
 #endif
   }
 
@@ -616,7 +615,10 @@ int main() {
   if (font_name[0] != 0) {
     font = XLoadQueryFont(display, font_name);
     if (font == NULL) {
-      fprintf(stderr, "could not load the specified font %s - trying to fall back to fixed\n", font_name);
+      fprintf(stderr,
+              "could not load the specified font %s - trying to fall back to "
+              "fixed\n",
+              font_name);
     }
   }
   if (font == NULL) {

--- a/helpers/auth_pam_x11.c
+++ b/helpers/auth_pam_x11.c
@@ -34,6 +34,7 @@ limitations under the License.
 
 #include "../env_settings.h"
 #include "../mlock_page.h"
+#include "../xscreensaver_api.h"
 #include "monitors.h"
 
 //! The blinking interval in microseconds.
@@ -601,9 +602,9 @@ int main() {
     return 1;
   }
 
-  window = GetUnsignedLongLongSetting("XSCREENSAVER_WINDOW", None);
+  window = ReadWindowID();
   if (window == None) {
-    fprintf(stderr, "Invalid window ID in XSCREENSAVER_WINDOW.\n");
+    fprintf(stderr, "Invalid/no window ID in XSCREENSAVER_WINDOW.\n");
     return 1;
   }
 

--- a/helpers/auth_pam_x11.c
+++ b/helpers/auth_pam_x11.c
@@ -14,28 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <X11/X.h>                // for Window, GCBackground, etc
-#include <X11/Xlib.h>             // for XDrawString, XGCValues, etc
-#include <ctype.h>                // for tolower, toupper
-#include <locale.h>               // for NULL, setlocale, LC_CTYPE
-#include <pwd.h>                  // for getpwuid, passwd
-#include <security/_pam_types.h>  // for PAM_SUCCESS, pam_strerror, etc
-#include <security/pam_appl.h>    // for pam_acct_mgmt, etc
-#include <stdio.h>                // for fprintf, stderr, NULL, etc
-#include <stdlib.h>               // for free, getenv, calloc, exit, etc
-#include <string.h>               // for strlen
-#include <sys/select.h>           // for select, FD_SET, FD_ZERO, etc
-#include <sys/time.h>             // for timeval
-#include <unistd.h>               // for getuid, sleep, ssize_t
+#include <X11/X.h>                  // for Atom, Success, None, GCBackground
+#include <X11/Xlib.h>               // for XDrawString, XTextWidth, XFontStruct
+#include <X11/extensions/XKB.h>     // for XkbUseCoreKbd, XkbGroupNamesMask
+#include <X11/extensions/XKBstr.h>  // for XkbStateRec, _XkbDesc, _XkbNamesRec
+#include <locale.h>                 // for NULL, setlocale, LC_CTYPE
+#include <pwd.h>                    // for getpwuid, passwd
+#include <security/_pam_types.h>    // for PAM_SUCCESS, pam_strerror, pam_re...
+#include <security/pam_appl.h>      // for pam_end, pam_start, pam_acct_mgmt
+#include <stdio.h>                  // for fprintf, stderr, perror, NULL
+#include <stdlib.h>                 // for mblen, exit, free, calloc, getenv
+#include <string.h>                 // for memcpy, strlen, memset
+#include <sys/select.h>             // for timeval, select, FD_SET, FD_ZERO
+#include <unistd.h>                 // for gethostname, getuid, read, ssize_t
 
 #ifdef HAVE_XKB
-#include <X11/XKBlib.h>
+#include <X11/XKBlib.h>             // for XkbFreeClientMap, XkbGetIndicator...
 #endif
 
-#include "../env_settings.h"
-#include "../mlock_page.h"
-#include "../xscreensaver_api.h"
-#include "monitors.h"
+#include "../env_settings.h"        // for GetStringSetting
+#include "../mlock_page.h"          // for MLOCK_PAGE
+#include "../xscreensaver_api.h"    // for ReadWindowID
+#include "monitors.h"               // for Monitor, GetMonitors, IsMonitorCh...
 
 //! The blinking interval in microseconds.
 #define BLINK_INTERVAL (250 * 1000)

--- a/helpers/auth_pam_x11.c
+++ b/helpers/auth_pam_x11.c
@@ -221,6 +221,9 @@ void display_string(const char *title, const char *str) {
   region_h = 3 * th;
 #endif
   region_y = -region_h / 2;
+
+  // Make the things just drawn appear on the screen as soon as possible.
+  XFlush(display);
 }
 
 /*! \brief Show a message to the user.

--- a/helpers/monitors.c
+++ b/helpers/monitors.c
@@ -1,0 +1,169 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "monitors.h"
+
+#include <X11/Xlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef HAVE_XRANDR
+#include <X11/extensions/Xrandr.h>
+#endif
+
+#ifdef HAVE_XRANDR
+static Display* initialized_for = NULL;
+static int supported;
+static int event_base;
+static int error_base;
+
+static int MaybeInitXRandR(Display* dpy) {
+  if (dpy != initialized_for) {
+    supported = 0;
+    if (XRRQueryExtension(dpy, &event_base, &error_base)) {
+      int major, minor;
+      if (XRRQueryVersion(dpy, &major, &minor)) {
+        // XRandR before 1.2 can't connect multiple screens to one, so the
+        // default root window size tracking is sufficient for that.
+        if (major > 1 || (major == 1 && minor >= 2)) {
+          supported = 1;
+        }
+      }
+    }
+    initialized_for = dpy;
+  }
+  return supported;
+}
+#endif
+
+#define CLAMP(x, mi, ma) ((x) < (mi) ? (mi) : (x) > (ma) ? (ma) : (x))
+
+static int compare_monitors(const void* a, const void* b) {
+  return memcmp(a, b, sizeof(Monitor));
+}
+
+size_t GetMonitors(Display* dpy, Window w, Monitor* out_monitors,
+                   size_t max_monitors) {
+  if (max_monitors < 1) {
+    return 0;
+  }
+
+  size_t num_monitors = 0;
+
+  // As outputs will be relative to the window, we have to query its attributes.
+  XWindowAttributes xwa;
+  XGetWindowAttributes(dpy, w, &xwa);
+
+#ifdef HAVE_XRANDR
+  if (MaybeInitXRandR(dpy)) {
+    XRRScreenResources* screenres = XRRGetScreenResources(dpy, w);
+    if (screenres != NULL) {
+      for (int k = 0; k < screenres->noutput; ++k) {
+        XRROutputInfo* output =
+            XRRGetOutputInfo(dpy, screenres, screenres->outputs[k]);
+        if (output != NULL) {
+          // NOTE: If an output has multiple Crtcs (i.e. if the screen is
+          // cloned), we only look at the first. Let's assume that the center of
+          // that one should always be onscreen anyway (even though they may not
+          // be, as cloned displays can have different panning settings).
+          RRCrtc crtc = (output->crtc ? output->crtc
+                                      : output->ncrtc ? output->crtcs[0] : 0);
+          XRRCrtcInfo* info = (crtc ? XRRGetCrtcInfo(dpy, screenres, crtc) : 0);
+          if (info != NULL) {
+            int x = CLAMP(info->x, xwa.x, xwa.x + xwa.width) - xwa.x;
+            int y = CLAMP(info->y, xwa.y, xwa.y + xwa.height) - xwa.y;
+            int w = CLAMP(info->x + (int)info->width, xwa.x + x,
+                          xwa.x + xwa.width) -
+                    (xwa.x + x);
+            int h = CLAMP(info->y + (int)info->height, xwa.y + y,
+                          xwa.y + xwa.height) -
+                    (xwa.y + y);
+            if (w <= 0 || h <= 0) {
+              continue;
+            }
+            if (num_monitors < max_monitors) {
+              out_monitors[num_monitors].x = x;
+              out_monitors[num_monitors].y = y;
+              out_monitors[num_monitors].width = w;
+              out_monitors[num_monitors].height = h;
+              ++num_monitors;
+            }
+            XRRFreeCrtcInfo(info);
+          }
+          XRRFreeOutputInfo(output);
+        }
+      }
+      XRRFreeScreenResources(screenres);
+    }
+  }
+#endif
+
+  // If we got no monitor info, try to guess based on size.
+  if (num_monitors == 0) {
+    // XRandR-less dummy fallback.
+    size_t guessed_monitors = CLAMP((size_t)(xwa.width * 9 + xwa.height * 8) /
+                                        (size_t)(xwa.height * 16),  //
+                                    1, max_monitors);
+    for (num_monitors = 0; num_monitors < guessed_monitors; ++num_monitors) {
+      out_monitors[num_monitors].x =
+          xwa.width * num_monitors / guessed_monitors;
+      out_monitors[num_monitors].y = 0;
+      out_monitors[num_monitors].width =
+          (xwa.width * (num_monitors + 1) / guessed_monitors) -
+          (xwa.width * num_monitors / guessed_monitors);
+      out_monitors[num_monitors].height = xwa.height;
+    }
+  }
+
+  // Sort the monitors in some deterministic order.
+  qsort(out_monitors, num_monitors, sizeof(*out_monitors), compare_monitors);
+
+  // Fill the rest with zeros.
+  if (num_monitors < max_monitors) {
+    memset(out_monitors + num_monitors, 0,
+           (max_monitors - num_monitors) * sizeof(*out_monitors));
+  }
+
+  return num_monitors;
+}
+
+void SelectMonitorChangeEvents(Display* dpy, Window w) {
+#ifdef HAVE_XRANDR
+  if (MaybeInitXRandR(dpy)) {
+    XRRSelectInput(dpy, w,
+                   RRScreenChangeNotifyMask | RRCrtcChangeNotifyMask |
+                       RROutputChangeNotifyMask);
+  }
+#endif
+}
+
+int IsMonitorChangeEvent(Display* dpy, int type) {
+#ifdef HAVE_XRANDR
+  if (MaybeInitXRandR(dpy)) {
+    switch (type - event_base) {
+      case RRScreenChangeNotify:
+      case RRNotify + RRNotify_CrtcChange:
+      case RRNotify + RRNotify_OutputChange:
+        return 1;
+      default:
+        return 0;
+    }
+  }
+#endif
+
+  // XRandR-less dummy fallback.
+  return 0;
+}

--- a/helpers/monitors.c
+++ b/helpers/monitors.c
@@ -21,12 +21,15 @@ limitations under the License.
 #include <stdlib.h>    // for qsort
 #include <string.h>    // for memcmp, memset
 
-#ifdef HAVE_XRANDR12
+#ifdef HAVE_XRANDR
 #include <X11/extensions/Xrandr.h>  // for XRRCrtcInfo, XRROutputInfo, XRRSc...
 #include <X11/extensions/randr.h>   // for RRNotify, RRCrtcChangeNotifyMask
+#if RANDR_MAJOR > 1 || (RANDR_MAJOR == 1 && RANDR_MINOR >= 5)
+#define HAVE_XRANDR15
+#endif
 #endif
 
-#ifdef HAVE_XRANDR12
+#ifdef HAVE_XRANDR
 static Display* initialized_for = NULL;
 static int have_xrandr12;
 #ifdef HAVE_XRANDR15
@@ -81,7 +84,7 @@ static int IntervalsOverlap(int astart, int asize, int bstart, int bsize) {
 }
 
 static void AddMonitor(Monitor* out_monitors, size_t* num_monitors,
-                size_t max_monitors, int x, int y, int w, int h) {
+                       size_t max_monitors, int x, int y, int w, int h) {
 #ifdef DEBUG_EVENTS
   fprintf(stderr, "try %d %d %d %d\n", x, y, w, h);
 #endif
@@ -131,7 +134,7 @@ size_t GetMonitors(Display* dpy, Window w, Monitor* out_monitors,
   XWindowAttributes xwa;
   XGetWindowAttributes(dpy, w, &xwa);
 
-#ifdef HAVE_XRANDR12
+#ifdef HAVE_XRANDR
   if (MaybeInitXRandR(dpy)) {
     // Translate to absolute coordinates so we can compare them to XRandR data.
     int wx, wy;
@@ -229,7 +232,7 @@ size_t GetMonitors(Display* dpy, Window w, Monitor* out_monitors,
 }
 
 void SelectMonitorChangeEvents(Display* dpy, Window w) {
-#ifdef HAVE_XRANDR12
+#ifdef HAVE_XRANDR
   if (MaybeInitXRandR(dpy)) {
     XRRSelectInput(dpy, w,
                    RRScreenChangeNotifyMask | RRCrtcChangeNotifyMask |
@@ -239,7 +242,7 @@ void SelectMonitorChangeEvents(Display* dpy, Window w) {
 }
 
 int IsMonitorChangeEvent(Display* dpy, int type) {
-#ifdef HAVE_XRANDR12
+#ifdef HAVE_XRANDR
   if (MaybeInitXRandR(dpy)) {
     switch (type - event_base) {
       case RRScreenChangeNotify:

--- a/helpers/monitors.c
+++ b/helpers/monitors.c
@@ -16,12 +16,14 @@ limitations under the License.
 
 #include "monitors.h"
 
-#include <X11/Xlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <X11/Xlib.h>               // for XWindowAttributes, Display, XGetW...
+#include <stdio.h>                  // for fprintf, stderr
+#include <stdlib.h>                 // for qsort
+#include <string.h>                 // for memcmp, memset
 
 #ifdef HAVE_XRANDR
-#include <X11/extensions/Xrandr.h>
+#include <X11/extensions/Xrandr.h>  // for XRRCrtcInfo, XRROutputInfo, XRRSc...
+#include <X11/extensions/randr.h>   // for RRNotify, RRCrtcChangeNotifyMask
 #endif
 
 #ifdef HAVE_XRANDR

--- a/helpers/monitors.c
+++ b/helpers/monitors.c
@@ -84,7 +84,7 @@ size_t GetMonitors(Display* dpy, Window w, Monitor* out_monitors,
       for (int k = 0; k < screenres->noutput; ++k) {
         XRROutputInfo* output =
             XRRGetOutputInfo(dpy, screenres, screenres->outputs[k]);
-        if (output != NULL) {
+        if (output != NULL && output->connection == RR_Connected) {
           // NOTE: If an output has multiple Crtcs (i.e. if the screen is
           // cloned), we only look at the first. Let's assume that the center of
           // that one should always be onscreen anyway (even though they may not

--- a/helpers/monitors.c
+++ b/helpers/monitors.c
@@ -16,10 +16,10 @@ limitations under the License.
 
 #include "monitors.h"
 
-#include <X11/Xlib.h>               // for XWindowAttributes, Display, XGetW...
-#include <stdio.h>                  // for fprintf, stderr
-#include <stdlib.h>                 // for qsort
-#include <string.h>                 // for memcmp, memset
+#include <X11/Xlib.h>  // for XWindowAttributes, Display, XGetW...
+#include <stdio.h>     // for fprintf, stderr
+#include <stdlib.h>    // for qsort
+#include <string.h>    // for memcmp, memset
 
 #ifdef HAVE_XRANDR
 #include <X11/extensions/Xrandr.h>  // for XRRCrtcInfo, XRROutputInfo, XRRSc...

--- a/helpers/monitors.h
+++ b/helpers/monitors.h
@@ -17,9 +17,9 @@ limitations under the License.
 #ifndef MONITORS_H
 #define MONITORS_H
 
-#include <stddef.h>    // for size_t
 #include <X11/X.h>     // for Window
 #include <X11/Xlib.h>  // for Display
+#include <stddef.h>    // for size_t
 
 typedef struct {
   int x, y, width, height;
@@ -43,7 +43,7 @@ size_t GetMonitors(Display* dpy, Window w, Monitor* out_monitors,
 
 /*! \brief Enable receiving monitor change events for the given display at w.
  */
-void SelectMonitorChangeEvents(Display *dpy, Window w);
+void SelectMonitorChangeEvents(Display* dpy, Window w);
 
 /*! \brief Returns the event type that indicates a change to the monitor
  *    configuration.

--- a/helpers/monitors.h
+++ b/helpers/monitors.h
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MONITORS_H
+#define MONITORS_H
+
+#include <stdlib.h>
+#include <X11/Xlib.h>
+
+typedef struct {
+  int x, y, width, height;
+} Monitor;
+
+/*! \brief Queries the current monitor configuration.
+ *
+ * Note: out_monitors will be zero padded and sorted in some deterministic order
+ * so memcmp can be used to check if the monitor configuration has actually
+ * changed.
+ *
+ * \param dpy The current display.
+ * \param w The window this application intends to draw in.
+ * \param out_monitors A pointer to an array that will receive the monitor
+ *   configuration (in coordinates relative and clipped to the window w.
+ * \param max_monitors The size of the array.
+ * \return The number of monitors returned in the array.
+ */
+size_t GetMonitors(Display* dpy, Window w, Monitor* out_monitors,
+                   size_t max_monitors);
+
+/*! \brief Enable receiving monitor change events for the given display at w.
+ */
+void SelectMonitorChangeEvents(Display *dpy, Window w);
+
+/*! \brief Returns the event type that indicates a change to the monitor
+ *    configuration.
+ *
+ * \param dpy The current display.
+ * \param type The received event type.
+ *
+ * \returns 1 if the received event is a monitor change event and GetMonitors
+ *   should be called, or 0 otherwise.
+ */
+int IsMonitorChangeEvent(Display* dpy, int type);
+
+#endif

--- a/helpers/monitors.h
+++ b/helpers/monitors.h
@@ -17,8 +17,9 @@ limitations under the License.
 #ifndef MONITORS_H
 #define MONITORS_H
 
-#include <stdlib.h>
-#include <X11/Xlib.h>
+#include <stddef.h>    // for size_t
+#include <X11/X.h>     // for Window
+#include <X11/Xlib.h>  // for Display
 
 typedef struct {
   int x, y, width, height;

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -1,0 +1,120 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <X11/X.h>                // for Window, GCBackground, etc
+#include <X11/Xlib.h>             // for XDrawString, XGCValues, etc
+#include <signal.h>
+#include <stdio.h>                // for fprintf, stderr, NULL, etc
+#include <stdlib.h>               // for free, getenv, calloc, exit, etc
+#include <string.h>               // for strlen
+
+#ifdef HAVE_XKB
+#include <X11/XKBlib.h>
+#endif
+
+#include "../saver_child.h"
+#include "../xscreensaver_api.h"
+#include "monitors.h"
+
+volatile int sigterm = 0;
+
+static void handle_sigterm(int) {
+  sigterm = 1;
+}
+
+#define MAX_MONITORS MAX_SAVERS
+
+static Display *display;
+static Monitor monitors[MAX_MONITORS];
+static size_t num_monitors;
+static Window windows[MAX_MONITORS];
+
+static void SpawnSavers(Window parent) {
+  XSetWindowAttributes attrs;
+  coverattrs.background_pixel = BlackPixel(display, DefaultScreen(display));;
+  for (size_t i = 0; i < num_monitors; ++i) {
+    windows[i] = XCreateWindow(display, parent, monitors[i].x, monitors[i].y,
+                               monitors[i].width, monitors[i].height, 0,
+                               CopyFromParent, InputOutput, CopyFromParent,
+                               CWBackPixel | CWCursor, &attrs);
+    XMapWindow(display, windows[i]);
+    WatchSaverChild(display, windows[i], i, saver_executable, 1);
+  }
+}
+
+static void KillSavers() {
+  for (size_t i = 0; i < num_monitors; ++i) {
+    WatchSaverChild(display, windows[i], i, saver_executable, 0);
+    XDestroyWindow(windows[i]);
+  }
+}
+
+/*! \brief The main program.
+ *
+ * Usage: XSCREENSAVER_WINDOW=window_id ./saver_multiplex
+ *
+ * Spawns spearate saver subprocesses, one on each screen.
+ */
+int main() {
+  if ((display = XOpenDisplay(NULL)) == NULL) {
+    fprintf(stderr, "could not connect to $DISPLAY\n");
+    return 1;
+  }
+
+  window = ReadWindowID();
+  if (window == None) {
+    fprintf(stderr, "Invalid/no window ID in XSCREENSAVER_WINDOW.\n");
+    return 1;
+  }
+
+  SelectMonitorChangeEvents(display, window);
+
+  num_monitors = GetMonitors(display, window, monitors, MAX_MONITORS);
+  SpawnSavers(window);
+
+  signal(SIGTERM, handle_sigterm);
+  for (;;) {
+    // We're using non-blocking X11 event handling and select() so we can
+    // reliably catch SIGTERM and exit the loop.
+    fd_set in_fds;
+    FD_ZERO(&in_fds);
+    FD_SET(x11_fd, &in_fds);
+    select(x11_fd + 1, &in_fds, 0, 0, NULL);
+    if (sigterm) {
+      break;
+    }
+    XEvent ev;
+    while (XPending(display) && (XNextEvent(display, &priv.ev), 1)) {
+      if (IsMonitorChangeEvent(ev)) {
+        Monitor new_monitors[MAX_SAVERS];
+        size_t new_num_monitors =
+            GetMonitors(display, window, monitors, MAX_SAVERS);
+        if (new_monitors != monitors ||
+            memcmp(new_monitors, monitors, sizeof(monitors))) {
+          KillSavers();
+          num_monitors = new_num_monitors;
+          memcpy(monitors, new_monitors, sizeof(monitors));
+          SpawnSavers(window);
+        }
+      }
+    }
+  }
+
+  // Kill all the savers when exiting.
+  KillSavers();
+
+  return 0;
+}

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -28,7 +28,7 @@ limitations under the License.
 #include "../xscreensaver_api.h"  // for ReadWindowID
 #include "monitors.h"             // for IsMonitorChangeEvent, Monitor, Sele...
 
-volatile int sigterm = 0;
+volatile sig_atomic_t sigterm = 0;
 
 static void handle_sigterm(int unused_signo) {
   (void)unused_signo;

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -120,7 +120,7 @@ int main() {
   sigset_t added_sigmask, old_sigmask;
   sigemptyset(&added_sigmask);
   sigaddset(&added_sigmask, SIGTERM);
-  sigaddset(&old_sigmask, SIGCHLD);
+  sigaddset(&added_sigmask, SIGCHLD);
   sigemptyset(&old_sigmask);
   if (sigprocmask(SIG_BLOCK, &added_sigmask, &old_sigmask) == 0) {
     // Only when we could actually block the signals, install the handlers.

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -14,21 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <X11/X.h>                // for Window, GCBackground, etc
-#include <X11/Xlib.h>             // for XDrawString, XGCValues, etc
-#include <signal.h>
-#include <stdio.h>                // for fprintf, stderr, NULL, etc
-#include <stdlib.h>               // for free, getenv, calloc, exit, etc
-#include <string.h>               // for strlen
+#include <X11/X.h>                // for Window, CopyFromParent, CWBackPixel
+#include <X11/Xlib.h>             // for XEvent, XFlush, XNextEvent, XOpenDi...
+#include <signal.h>               // for signal, SIGTERM
+#include <stdio.h>                // for fprintf, NULL, stderr
+#include <string.h>               // for memcmp, memcpy
+#include <sys/select.h>           // for select, FD_SET, FD_ZERO, fd_set
 
-#ifdef HAVE_XKB
-#include <X11/XKBlib.h>
-#endif
-
-#include "../env_settings.h"
-#include "../saver_child.h"
-#include "../xscreensaver_api.h"
-#include "monitors.h"
+#include "../env_settings.h"      // for GetStringSetting
+#include "../saver_child.h"       // for MAX_SAVERS
+#include "../xscreensaver_api.h"  // for ReadWindowID
+#include "monitors.h"             // for IsMonitorChangeEvent, Monitor, Sele...
 
 volatile int sigterm = 0;
 

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <X11/X.h>                // for Window, CopyFromParent, CWBackPixel
-#include <X11/Xlib.h>             // for XEvent, XFlush, XNextEvent, XOpenDi...
-#include <signal.h>               // for signal, SIGTERM
-#include <stdio.h>                // for fprintf, NULL, stderr
-#include <string.h>               // for memcmp, memcpy
-#include <sys/select.h>           // for select, FD_SET, FD_ZERO, fd_set
+#include <X11/X.h>       // for Window, CopyFromParent, CWBackPixel
+#include <X11/Xlib.h>    // for XEvent, XFlush, XNextEvent, XOpenDi...
+#include <signal.h>      // for signal, SIGTERM
+#include <stdio.h>       // for fprintf, NULL, stderr
+#include <string.h>      // for memcmp, memcpy
+#include <sys/select.h>  // for select, FD_SET, FD_ZERO, fd_set
 
 #include "../env_settings.h"      // for GetStringSetting
 #include "../saver_child.h"       // for MAX_SAVERS
@@ -29,7 +29,7 @@ limitations under the License.
 volatile int sigterm = 0;
 
 static void handle_sigterm(int unused_signo) {
-  (void) unused_signo;
+  (void)unused_signo;
   sigterm = 1;
 }
 
@@ -50,7 +50,8 @@ static void WatchSavers(void) {
 
 static void SpawnSavers(Window parent) {
   XSetWindowAttributes attrs;
-  attrs.background_pixel = BlackPixel(display, DefaultScreen(display));;
+  attrs.background_pixel = BlackPixel(display, DefaultScreen(display));
+  ;
   for (size_t i = 0; i < num_monitors; ++i) {
     windows[i] =
         XCreateWindow(display, parent, monitors[i].x, monitors[i].y,

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -56,12 +56,14 @@ static void SpawnSavers(Window parent) {
   XSetWindowAttributes attrs;
   attrs.background_pixel = BlackPixel(display, DefaultScreen(display));;
   for (size_t i = 0; i < num_monitors; ++i) {
-    windows[i] = XCreateWindow(display, parent, monitors[i].x, monitors[i].y,
-                               monitors[i].width, monitors[i].height, 0,
-                               CopyFromParent, InputOutput, CopyFromParent,
-                               CWBackPixel | CWCursor, &attrs);
-    XMapWindow(display, windows[i]);
+    windows[i] =
+        XCreateWindow(display, parent, monitors[i].x, monitors[i].y,
+                      monitors[i].width, monitors[i].height, 0, CopyFromParent,
+                      InputOutput, CopyFromParent, CWBackPixel, &attrs);
+    XMapRaised(display, windows[i]);
   }
+  // Need to flush the display so savers sure can access the window.
+  XFlush(display);
   WatchSavers();
 }
 

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -35,6 +35,12 @@ static void handle_sigterm(int unused_signo) {
   sigterm = 1;
 }
 
+static void handle_sigchld(int unused_signo) {
+  // No handling needed - we just want to interrupt the select() in the main
+  // loop.
+  (void)unused_signo;
+}
+
 #define MAX_MONITORS MAX_SAVERS
 
 static const char *saver_executable;
@@ -108,6 +114,7 @@ int main() {
   SpawnSavers(parent);
 
   signal(SIGTERM, handle_sigterm);
+  signal(SIGCHLD, handle_sigchld);
   for (;;) {
     // We're using non-blocking X11 event handling and select() so we can
     // reliably catch SIGTERM and exit the loop. Also, SIGCHLD (screen saver

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -96,8 +96,8 @@ int main() {
   saver_executable = GetStringSetting("XSECURELOCK_SAVER", SAVER_EXECUTABLE);
 
   SelectMonitorChangeEvents(display, parent);
-
   num_monitors = GetMonitors(display, parent, monitors, MAX_MONITORS);
+
   SpawnSavers(parent);
 
   signal(SIGTERM, handle_sigterm);

--- a/helpers/saver_xscreensaver
+++ b/helpers/saver_xscreensaver
@@ -45,7 +45,10 @@ while IFS= read -r saver; do
   [[ -f ${saver%% *} ]] || continue
   # Rest is the command line!
   (( ++random_count ))
-  if (( RANDOM % random_count == 0 )); then
+  # We're using the parent process ID here, which may be a saver_multiplex
+  # instance. This ensures that multiple instances of this always spawn the same
+  # saver on each screen.
+  if (( PPID % random_count == 0 )); then
     random_saver=${saver}
   fi
 done < <(allsavers)

--- a/main.c
+++ b/main.c
@@ -21,35 +21,39 @@ limitations under the License.
   *security.
  */
 
-#include <X11/X.h>       // for CopyFromParent, etc
-#include <X11/Xlib.h>    // for XEvent, etc
-#include <X11/Xutil.h>   // for XLookupString
-#include <errno.h>       // for ECHILD, EINTR, errno
-#include <locale.h>      // for NULL, setlocale, LC_CTYPE
-#include <signal.h>      // for sigaction, sigemptyset, etc
-#include <stdio.h>       // for fprintf, stderr
-#include <stdlib.h>      // for EXIT_SUCCESS
-#include <string.h>      // for strchr, strncmp
-#include <sys/select.h>  // for select, FD_SET, FD_ZERO, etc
-#include <sys/time.h>    // for timeval
-#include <sys/wait.h>    // for waitpid, WEXITSTATUS, etc
-#include <time.h>        // for nanosleep, timespec
-#include <unistd.h>      // for access, X_OK
+#include <X11/X.h>                      // for Window, GrabModeAsync, None
+#include <X11/Xlib.h>                   // for XEvent, XSelectInput, XSetWin...
+#include <X11/Xutil.h>                  // for XLookupString
+#include <errno.h>                      // for ECHILD, EINTR, errno
+#include <locale.h>                     // for NULL, setlocale, LC_CTYPE
+#include <signal.h>                     // for sigaction, sigemptyset, SIGPIPE
+#include <stdio.h>                      // for fprintf, stderr, perror, printf
+#include <stdlib.h>                     // for EXIT_SUCCESS, WEXITSTATUS, exit
+#include <string.h>                     // for __s1_len, __s2_len, strncmp
+#include <sys/select.h>                 // for timeval, select, FD_SET, FD_ZERO
+#include <sys/wait.h>                   // for waitpid, WNOHANG
+#include <time.h>                       // for nanosleep, timespec
+#include <unistd.h>                     // for access, pid_t, X_OK, chdir
+#include "auth_child.h"                 // for WantAuthChild, WatchAuthChild
+#include "env_settings.h"               // for GetIntSetting, GetStringSetting
+#include "mlock_page.h"                 // for MLOCK_PAGE
+#include "saver_child.h"                // for WatchSaverChild
 
 #ifdef HAVE_SCRNSAVER
-#include <X11/extensions/scrnsaver.h>
+#include <X11/extensions/saver.h>       // for ScreenSaverNotify, ScreenSave...
+#include <X11/extensions/scrnsaver.h>   // for XScreenSaverNotifyEvent, XScr...
 #endif
 #ifdef HAVE_COMPOSITE
-#include <X11/extensions/Xcomposite.h>
+#include <X11/extensions/Xcomposite.h>  // for XCompositeGetOverlayWindow
 #endif
 #ifdef HAVE_XF86MISC
-#include <X11/extensions/xf86misc.h>
+#include <X11/extensions/xf86misc.h>    // for XF86MiscSetGrabKeysState
 #endif
 
-#include "auth_child.h"
-#include "env_settings.h"
-#include "mlock_page.h"
-#include "saver_child.h"
+#include "auth_child.h"                 // for WantAuthChild, WatchAuthChild
+#include "env_settings.h"               // for GetIntSetting, GetStringSetting
+#include "mlock_page.h"                 // for MLOCK_PAGE
+#include "saver_child.h"                // for WatchSaverChild
 
 /*! \brief How often (in times per second) to watch child processes.
  *

--- a/main.c
+++ b/main.c
@@ -605,6 +605,9 @@ int main(int argc, char **argv) {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, NULL);
 
+  // Need to flush the display so savers sure can access the window.
+  XFlush(display);
+
   enum WatchChildrenState requested_saver_state = WATCH_CHILDREN_NORMAL;
   int x11_fd = ConnectionNumber(display);
   int background_window_mapped = 0, saver_window_mapped = 0,

--- a/main.c
+++ b/main.c
@@ -202,7 +202,8 @@ void usage(const char *me) {
       "  XSECURELOCK_WANT_FIRST_KEYPRESS=<0|1>\n"
       "\n"
       "Default auth module: " AUTH_EXECUTABLE "\n"
-      "Default saver module: " SAVER_EXECUTABLE "\n"
+      "Default global saver module: " GLOBAL_SAVER_EXECUTABLE "\n"
+      "Default per-screen saver module: " SAVER_EXECUTABLE "\n"
       "\n"
       "This software is licensed under the Apache 2.0 License. Details are\n"
       "available at the following location:\n"
@@ -216,7 +217,8 @@ void usage(const char *me) {
  */
 void load_defaults() {
   auth_executable = GetStringSetting("XSECURELOCK_AUTH", AUTH_EXECUTABLE);
-  saver_executable = GetStringSetting("XSECURELOCK_SAVER", SAVER_EXECUTABLE);
+  saver_executable =
+      GetStringSetting("XSECURELOCK_GLOBAL_SAVER", GLOBAL_SAVER_EXECUTABLE);
 #ifdef HAVE_COMPOSITE
   no_composite = GetIntSetting("XSECURELOCK_NO_COMPOSITE", 0);
 #endif

--- a/main.c
+++ b/main.c
@@ -15,45 +15,45 @@ limitations under the License.
 */
 
 /*!
-  *\brief XSecureLock.
+ *\brief XSecureLock.
  *
-  *XSecureLock is an X11 screen lock utility designed with the primary goal of
-  *security.
+ *XSecureLock is an X11 screen lock utility designed with the primary goal of
+ *security.
  */
 
-#include <X11/X.h>                      // for Window, GrabModeAsync, None
-#include <X11/Xlib.h>                   // for XEvent, XSelectInput, XSetWin...
-#include <X11/Xutil.h>                  // for XLookupString
-#include <errno.h>                      // for ECHILD, EINTR, errno
-#include <locale.h>                     // for NULL, setlocale, LC_CTYPE
-#include <signal.h>                     // for sigaction, sigemptyset, SIGPIPE
-#include <stdio.h>                      // for fprintf, stderr, perror, printf
-#include <stdlib.h>                     // for EXIT_SUCCESS, WEXITSTATUS, exit
-#include <string.h>                     // for __s1_len, __s2_len, strncmp
-#include <sys/select.h>                 // for timeval, select, FD_SET, FD_ZERO
-#include <sys/wait.h>                   // for waitpid, WNOHANG
-#include <time.h>                       // for nanosleep, timespec
-#include <unistd.h>                     // for access, pid_t, X_OK, chdir
-#include "auth_child.h"                 // for WantAuthChild, WatchAuthChild
-#include "env_settings.h"               // for GetIntSetting, GetStringSetting
-#include "mlock_page.h"                 // for MLOCK_PAGE
-#include "saver_child.h"                // for WatchSaverChild
+#include <X11/X.h>         // for Window, GrabModeAsync, None
+#include <X11/Xlib.h>      // for XEvent, XSelectInput, XSetWin...
+#include <X11/Xutil.h>     // for XLookupString
+#include <errno.h>         // for ECHILD, EINTR, errno
+#include <locale.h>        // for NULL, setlocale, LC_CTYPE
+#include <signal.h>        // for sigaction, sigemptyset, SIGPIPE
+#include <stdio.h>         // for fprintf, stderr, perror, printf
+#include <stdlib.h>        // for EXIT_SUCCESS, WEXITSTATUS, exit
+#include <string.h>        // for __s1_len, __s2_len, strncmp
+#include <sys/select.h>    // for timeval, select, FD_SET, FD_ZERO
+#include <sys/wait.h>      // for waitpid, WNOHANG
+#include <time.h>          // for nanosleep, timespec
+#include <unistd.h>        // for access, pid_t, X_OK, chdir
+#include "auth_child.h"    // for WantAuthChild, WatchAuthChild
+#include "env_settings.h"  // for GetIntSetting, GetStringSetting
+#include "mlock_page.h"    // for MLOCK_PAGE
+#include "saver_child.h"   // for WatchSaverChild
 
 #ifdef HAVE_SCRNSAVER
-#include <X11/extensions/saver.h>       // for ScreenSaverNotify, ScreenSave...
-#include <X11/extensions/scrnsaver.h>   // for XScreenSaverNotifyEvent, XScr...
+#include <X11/extensions/saver.h>      // for ScreenSaverNotify, ScreenSave...
+#include <X11/extensions/scrnsaver.h>  // for XScreenSaverNotifyEvent, XScr...
 #endif
 #ifdef HAVE_COMPOSITE
 #include <X11/extensions/Xcomposite.h>  // for XCompositeGetOverlayWindow
 #endif
 #ifdef HAVE_XF86MISC
-#include <X11/extensions/xf86misc.h>    // for XF86MiscSetGrabKeysState
+#include <X11/extensions/xf86misc.h>  // for XF86MiscSetGrabKeysState
 #endif
 
-#include "auth_child.h"                 // for WantAuthChild, WatchAuthChild
-#include "env_settings.h"               // for GetIntSetting, GetStringSetting
-#include "mlock_page.h"                 // for MLOCK_PAGE
-#include "saver_child.h"                // for WatchSaverChild
+#include "auth_child.h"    // for WantAuthChild, WatchAuthChild
+#include "env_settings.h"  // for GetIntSetting, GetStringSetting
+#include "mlock_page.h"    // for MLOCK_PAGE
+#include "saver_child.h"   // for WatchSaverChild
 
 /*! \brief How often (in times per second) to watch child processes.
  *
@@ -168,7 +168,7 @@ int WatchChildren(Display *dpy, Window w, enum WatchChildrenState state,
  *
  * \return If true, authentication was successful, and the program should exit.
  */
-int WakeUp(Display* dpy, Window w, const char *stdinbuf) {
+int WakeUp(Display *dpy, Window w, const char *stdinbuf) {
   return WatchChildren(dpy, w, WATCH_CHILDREN_FORCE_AUTH, stdinbuf);
 }
 
@@ -205,9 +205,12 @@ void usage(const char *me) {
       "  XSECURELOCK_SAVER=<saver module>\n"
       "  XSECURELOCK_WANT_FIRST_KEYPRESS=<0|1>\n"
       "\n"
-      "Default auth module: " AUTH_EXECUTABLE "\n"
-      "Default global saver module: " GLOBAL_SAVER_EXECUTABLE "\n"
-      "Default per-screen saver module: " SAVER_EXECUTABLE "\n"
+      "Default auth module: " AUTH_EXECUTABLE
+      "\n"
+      "Default global saver module: " GLOBAL_SAVER_EXECUTABLE
+      "\n"
+      "Default per-screen saver module: " SAVER_EXECUTABLE
+      "\n"
       "\n"
       "This software is licensed under the Apache 2.0 License. Details are\n"
       "available at the following location:\n"
@@ -448,8 +451,8 @@ int main(int argc, char **argv) {
   Window parent_window = root_window;
 
 #ifdef HAVE_COMPOSITE
-  int composite_event_base, composite_error_base,
-      composite_major_version = 0, composite_minor_version = 0;
+  int composite_event_base, composite_error_base, composite_major_version = 0,
+                                                  composite_minor_version = 0;
   int have_composite =
       XCompositeQueryExtension(display, &composite_event_base,
                                &composite_error_base) &&
@@ -486,8 +489,7 @@ int main(int argc, char **argv) {
       CopyFromParent, CWBackPixel | CWCursor, &coverattrs);
 
   // Let's get notified if we lose visibility, so we can self-raise.
-  XSelectInput(display, parent_window,
-               StructureNotifyMask | FocusChangeMask);
+  XSelectInput(display, parent_window, StructureNotifyMask | FocusChangeMask);
   XSelectInput(display, background_window,
                StructureNotifyMask | VisibilityChangeMask | FocusChangeMask);
   XSelectInput(display, saver_window,

--- a/main.c
+++ b/main.c
@@ -135,14 +135,14 @@ int WatchChildren(Display *dpy, Window w, enum WatchChildrenState state,
   // later.
   if (auth_running) {
     // Make sure the saver is shut down to not interfere with the screen.
-    WatchSaverChild(dpy, w, saver_executable, 0);
+    WatchSaverChild(dpy, w, 0, saver_executable, 0);
 
     // Actually start the auth child, or notice termination.
     if (WatchAuthChild(dpy, w, auth_executable,
                        state == WATCH_CHILDREN_FORCE_AUTH, stdinbuf,
                        &auth_running)) {
       // Auth performed successfully. Terminate the other children.
-      WatchSaverChild(dpy, w, saver_executable, 0);
+      WatchSaverChild(dpy, w, 0, saver_executable, 0);
       // Now terminate the screen lock.
       return 1;
     }
@@ -152,7 +152,7 @@ int WatchChildren(Display *dpy, Window w, enum WatchChildrenState state,
   // didn't start one, or because it just terminated.
   // Show the screen saver.
   if (!auth_running) {
-    WatchSaverChild(dpy, w, saver_executable,
+    WatchSaverChild(dpy, w, 0, saver_executable,
                     state != WATCH_CHILDREN_SAVER_DISABLED);
   }
 

--- a/main.c
+++ b/main.c
@@ -493,16 +493,6 @@ int main(int argc, char **argv) {
   XConfigureWindow(display, background_window, CWStackMode, &coverchanges);
   XConfigureWindow(display, saver_window, CWStackMode, &coverchanges);
 
-  // Now provide the window ID as an environment variable (like XScreenSaver).
-  char window_id_str[16];
-  size_t window_id_len = snprintf(window_id_str, sizeof(window_id_str), "%lu",
-                                  (unsigned long)saver_window);
-  if (window_id_len <= 0 || window_id_len >= sizeof(window_id_str)) {
-    fprintf(stderr, "Window ID doesn't fit into buffer.\n");
-    return 1;
-  }
-  setenv("XSCREENSAVER_WINDOW", window_id_str, 1);
-
   // Initialize XInput so we can get multibyte key events.
   XIM xim = XOpenIM(display, NULL, NULL, NULL);
   if (xim == NULL) {

--- a/saver_child.c
+++ b/saver_child.c
@@ -23,23 +23,28 @@ limitations under the License.
 #include <sys/wait.h>  // for WEXITSTATUS, waitpid, etc
 #include <unistd.h>    // for pid_t, execl, fork, setsid
 
-//! The PID of a currently running saver child, or 0 if none is running.
-static pid_t saver_child_pid = 0;
+//! The PIDs of currently running saver children, or 0 if not running.
+static pid_t saver_child_pid[MAX_SAVERS] = {0};
 
-void WatchSaverChild(Display* dpy, Window w, const char* executable,
+void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
                      int should_be_running) {
-  if (!should_be_running && saver_child_pid != 0) {
+  if (index < 0 || index >= MAX_SAVERS) {
+    fprintf(stderr, "Saver index out of range: !(0 <= %d < %d).", index,
+            MAX_SAVERS);
+    return;
+  }
+  if (!should_be_running && saver_child_pid[index] != 0) {
     // Kill the whole process group.
-    kill(saver_child_pid, SIGTERM);
-    kill(-saver_child_pid, SIGTERM);
-    while (saver_child_pid) {
+    kill(saver_child_pid[index], SIGTERM);
+    kill(-saver_child_pid[index], SIGTERM);
+    while (saver_child_pid[index]) {
       int status;
-      pid_t pid = waitpid(saver_child_pid, &status, 0);
+      pid_t pid = waitpid(saver_child_pid[index], &status, 0);
       if (pid < 0) {
         switch (errno) {
           case ECHILD:
             // The process is dead. Fine.
-            saver_child_pid = 0;
+            saver_child_pid[index] = 0;
             break;
           case EINTR:
             // Waitpid was interrupted. Need to retry.
@@ -49,14 +54,14 @@ void WatchSaverChild(Display* dpy, Window w, const char* executable,
             perror("waitpid");
             break;
         }
-      } else if (pid == saver_child_pid) {
+      } else if (pid == saver_child_pid[index]) {
         if (WIFEXITED(status)) {
           // The process did exit.
           if (WEXITSTATUS(status) != EXIT_SUCCESS) {
             fprintf(stderr, "Saver child failed with status %d.\n",
                     WEXITSTATUS(status));
           }
-          saver_child_pid = 0;
+          saver_child_pid[index] = 0;
           // Now is the time to remove anything the child may have displayed.
           XClearWindow(dpy, w);
         }
@@ -79,7 +84,7 @@ void WatchSaverChild(Display* dpy, Window w, const char* executable,
       exit(EXIT_FAILURE);
     } else {
       // Parent process after successful fork.
-      saver_child_pid = pid;
+      saver_child_pid[index] = pid;
     }
   }
 }

--- a/saver_child.c
+++ b/saver_child.c
@@ -23,6 +23,8 @@ limitations under the License.
 #include <sys/wait.h>  // for WEXITSTATUS, waitpid, etc
 #include <unistd.h>    // for pid_t, execl, fork, setsid
 
+#include "xscreensaver_api.h"
+
 //! The PIDs of currently running saver children, or 0 if not running.
 static pid_t saver_child_pid[MAX_SAVERS] = {0};
 
@@ -79,6 +81,7 @@ void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
     } else if (pid == 0) {
       // Child process.
       setsid();
+      ExportWindowID(w);
       execl(executable, executable, NULL);
       perror("execl");
       exit(EXIT_FAILURE);

--- a/saver_child.c
+++ b/saver_child.c
@@ -35,6 +35,7 @@ void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
             MAX_SAVERS);
     return;
   }
+
   if (!should_be_running && saver_child_pid[index] != 0) {
     // Kill the whole process group.
     kill(saver_child_pid[index], SIGTERM);
@@ -74,7 +75,7 @@ void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
     }
   }
 
-  if (should_be_running && saver_child_pid == 0) {
+  if (should_be_running && saver_child_pid[index] == 0) {
     pid_t pid = fork();
     if (pid == -1) {
       perror("fork");

--- a/saver_child.h
+++ b/saver_child.h
@@ -19,17 +19,20 @@ limitations under the License.
 
 #include <X11/Xlib.h>
 
+#define MAX_SAVERS 16
+
 /*! \brief Starts or stops the screen saver child process.
  *
  * \param dpy The X11 display.
  * \param w The screen saver window. Will get cleared after saver child
  *   execution.
+ * \param index The index of the saver to maintain (0 <= index < MAX_SAVERS).
  * \param executable What binary to spawn for screen saving. No arguments will
  *   be passed.
  * \param should_be_running If true, the saver child is started if not running
  *   yet; if alse, the saver child will be terminated.
  */
-void WatchSaverChild(Display* dpy, Window w, const char* executable,
-                     int should_be_running);
+void WatchSaverChild(Display* dpy, Window w, int index,
+                     const char* executable, int should_be_running);
 
 #endif

--- a/saver_child.h
+++ b/saver_child.h
@@ -17,7 +17,8 @@ limitations under the License.
 #ifndef SAVER_CHILD_H
 #define SAVER_CHILD_H
 
-#include <X11/Xlib.h>
+#include <X11/X.h>     // for Window
+#include <X11/Xlib.h>  // for Display
 
 #define MAX_SAVERS 16
 

--- a/saver_child.h
+++ b/saver_child.h
@@ -33,7 +33,7 @@ limitations under the License.
  * \param should_be_running If true, the saver child is started if not running
  *   yet; if alse, the saver child will be terminated.
  */
-void WatchSaverChild(Display* dpy, Window w, int index,
-                     const char* executable, int should_be_running);
+void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
+                     int should_be_running);
 
 #endif

--- a/test/run-in-xephyr.sh
+++ b/test/run-in-xephyr.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
+set -ex
 make -C .. CPPFLAGS+=-DDEBUG_EVENTS clean all
 startx \
   "$PWD"/../xsecurelock \
   -- \
   "$(which Xephyr)" :42 -retro -screen 800x480 -screen 1280x720 \
-  +xinerama -resizeable
+  +extension RANDR +xinerama -resizeable
 make -C .. clean all

--- a/test/run-in-xephyr.sh
+++ b/test/run-in-xephyr.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export XSECURELOCK_SAVER=saver_xscreensaver
+
 set -ex
 make -C .. CPPFLAGS+=-DDEBUG_EVENTS clean all
 startx \

--- a/xscreensaver_api.c
+++ b/xscreensaver_api.c
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "xscreensaver_api.h"
+
+#include <X11/Xlib.h>
+#include <stdio.h>
+
+void ExportWindowID(Window w) {
+  char window_id_str[32];
+  size_t window_id_len = snprintf(window_id_str, sizeof(window_id_str), "%llu",
+                                  (unsigned long long)w);
+  if (window_id_len <= 0 || window_id_len >= sizeof(window_id_str)) {
+    fprintf(stderr, "Window ID doesn't fit into buffer.\n");
+    return;
+  }
+  setenv("XSCREENSAVER_WINDOW", window_id_str, 1);
+}
+
+Window ReadWindowID(void) {
+  return GetUnsignedLongLongSetting("XSCREENSAVER_WINDOW", None);
+}

--- a/xscreensaver_api.c
+++ b/xscreensaver_api.c
@@ -16,11 +16,11 @@ limitations under the License.
 
 #include "xscreensaver_api.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <X11/Xlib.h>
+#include <X11/X.h>         // for Window
+#include <stdio.h>         // for fprintf, stderr
+#include <stdlib.h>        // for setenv
 
-#include "env_settings.h"
+#include "env_settings.h"  // for GetUnsignedLongLongSetting
 
 void ExportWindowID(Window w) {
   char window_id_str[32];

--- a/xscreensaver_api.c
+++ b/xscreensaver_api.c
@@ -16,9 +16,9 @@ limitations under the License.
 
 #include "xscreensaver_api.h"
 
-#include <X11/X.h>         // for Window
-#include <stdio.h>         // for fprintf, stderr
-#include <stdlib.h>        // for setenv
+#include <X11/X.h>   // for Window
+#include <stdio.h>   // for fprintf, stderr
+#include <stdlib.h>  // for setenv
 
 #include "env_settings.h"  // for GetUnsignedLongLongSetting
 

--- a/xscreensaver_api.c
+++ b/xscreensaver_api.c
@@ -16,8 +16,11 @@ limitations under the License.
 
 #include "xscreensaver_api.h"
 
-#include <X11/Xlib.h>
+#include <stdlib.h>
 #include <stdio.h>
+#include <X11/Xlib.h>
+
+#include "env_settings.h"
 
 void ExportWindowID(Window w) {
   char window_id_str[32];

--- a/xscreensaver_api.h
+++ b/xscreensaver_api.h
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef XSCREENSAVER_API_H
+#define XSCREENSAVER_API_H
+
+#include <X11/Xlib.h>
+
+/*! \brief Export the given window ID to the environment for a saver/auth child.
+ *
+ * This simply sets $XSCREENSAVER_WINDOW.
+ *
+ * \param w The window the child should draw on.
+ */
+void ExportWindowID(Window w);
+
+/*! \brief Reads the window ID to draw on from the environment.
+ *
+ * This simply reads $XSCREENSAVER_WINDOW.
+ */
+Window ReadWindowID(void);
+
+#endif

--- a/xscreensaver_api.h
+++ b/xscreensaver_api.h
@@ -17,7 +17,7 @@ limitations under the License.
 #ifndef XSCREENSAVER_API_H
 #define XSCREENSAVER_API_H
 
-#include <X11/Xlib.h>
+#include <X11/X.h>  // for Window
 
 /*! \brief Export the given window ID to the environment for a saver/auth child.
  *


### PR DESCRIPTION
This adds multi monitor support (and some pre-work for Zaphod support) into auth_pam_x11 (one centered input area on each monitor) and the saver framework.

It should work transparently, but one should note that it works by a multiplexing process that watches for monitor changes and starts/stops savers.