### PR TITLE
Mpv does not support --heartbeat-cmd anymore

### DIFF
--- a/helpers/saver_mpv.in
+++ b/helpers/saver_mpv.in
@@ -19,7 +19,6 @@ video=`find ~/Videos -type f | sort -R | head -n 1`
   --no-input-terminal \
   --really-quiet \
   --no-stop-screensaver \
-  --heartbeat-cmd="" \
   --wid="${XSCREENSAVER_WINDOW}" \
   --no-audio \
   -- \


### PR DESCRIPTION
I only removed the `--heartbeat-cmd` option which prevented my mpv to start

---

My `mpv` version:
```
% mpv --version
mpv 0.28.2 (C) 2000-2017 mpv/MPlayer/mplayer2 projects
 built on Mon May 14 09:49:30 CEST 2018
ffmpeg library versions:
   libavutil       56.14.100
   libavcodec      58.18.100
   libavformat     58.12.100
   libswscale      5.1.100
   libavfilter     7.16.100
   libswresample   3.1.100
ffmpeg version: 4.0
```