### PR TITLE
Default XSECURELOCK_FORCE_GRAB to 0

### DIFF
--- a/main.c
+++ b/main.c
@@ -245,7 +245,7 @@ void load_defaults() {
 #endif
   have_switch_user_command =
       *GetStringSetting("XSECURELOCK_SWITCH_USER_COMMAND", "");
-  force_grab = GetIntSetting("XSECURELOCK_FORCE_GRAB", 1);
+  force_grab = GetIntSetting("XSECURELOCK_FORCE_GRAB", 0);
 }
 
 /*! \brief Parse the command line arguments.


### PR DESCRIPTION
The option is quite intrusive, and the documentation states "use with care", so I think it makes sense to default it to off.