### PR TITLE
Use a separate window for auth, keep saver alive

### DIFF
--- a/auth_child.c
+++ b/auth_child.c
@@ -116,8 +116,6 @@ int WatchAuthChild(Display *dpy, Window w, const char *executable,
         kill(-auth_child_pid, SIGTERM);
         auth_child_pid = 0;
         close(auth_child_fd);
-        // Now is the time to remove anything the child may have displayed.
-        XClearWindow(dpy, w);
         // If auth child exited with success status, stop the screen saver.
         if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS) {
           *auth_running = 0;

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -840,6 +840,9 @@ int prompt(const char *msg, char **response, int echo) {
       if (IsMonitorChangeEvent(display, priv.ev.type)) {
         num_monitors = GetMonitors(display, window, monitors, MAX_MONITORS);
         XClearWindow(display, window);
+        int w = DisplayWidth(display, DefaultScreen(display));
+        int h = DisplayHeight(display, DefaultScreen(display));
+        XMoveResizeWindow(display, window, 0, 0, w, h);
       }
     }
   }
@@ -1174,9 +1177,13 @@ int main() {
 #endif
 
   XSetWindowBackground(display, window, Background);
+  XMapRaised(display, window);
 
   SelectMonitorChangeEvents(display, window);
   num_monitors = GetMonitors(display, window, monitors, MAX_MONITORS);
+  int w = DisplayWidth(display, DefaultScreen(display));
+  int h = DisplayHeight(display, DefaultScreen(display));
+  XMoveResizeWindow(display, window, 0, 0, w, h);
 
   int status = authenticate();
 

--- a/helpers/monitors.c
+++ b/helpers/monitors.c
@@ -132,9 +132,9 @@ static void AddMonitor(Monitor* out_monitors, size_t* num_monitors,
 }
 
 #ifdef HAVE_XRANDR_EXT
-static int GetMonitorsXRandR12(Display* dpy, Window w, int wx, int wy, int ww,
-                               int wh, Monitor* out_monitors,
-                               size_t* out_num_monitors, size_t max_monitors) {
+static int GetMonitorsXRandR12(Display* dpy, Window w, int wx, int wy,
+                               Monitor* out_monitors, size_t* out_num_monitors,
+                               size_t max_monitors) {
   XRRScreenResources* screenres = XRRGetScreenResources(dpy, w);
   if (screenres == NULL) {
     return 0;
@@ -156,10 +156,10 @@ static int GetMonitorsXRandR12(Display* dpy, Window w, int wx, int wy, int ww,
           (output->crtc ? output->crtc : output->ncrtc ? output->crtcs[0] : 0);
       XRRCrtcInfo* info = (crtc ? XRRGetCrtcInfo(dpy, screenres, crtc) : 0);
       if (info != NULL) {
-        int x = CLAMP(info->x, wx, wx + ww) - wx;
-        int y = CLAMP(info->y, wy, wy + wh) - wy;
-        int w = CLAMP(info->x + (int)info->width, wx + x, wx + ww) - (wx + x);
-        int h = CLAMP(info->y + (int)info->height, wy + y, wy + wh) - (wy + y);
+        int x = info->x - wx;
+        int y = info->y - wy;
+        int w = info->x + (int)info->width - (wx + x);
+        int h = info->y + (int)info->height - (wy + y);
         AddMonitor(out_monitors, out_num_monitors, max_monitors, x, y, w, h);
         XRRFreeCrtcInfo(info);
       }
@@ -171,9 +171,9 @@ static int GetMonitorsXRandR12(Display* dpy, Window w, int wx, int wy, int ww,
 }
 
 #ifdef HAVE_XRANDR15_EXT
-static int GetMonitorsXRandR15(Display* dpy, Window w, int wx, int wy, int ww,
-                               int wh, Monitor* out_monitors,
-                               size_t* out_num_monitors, size_t max_monitors) {
+static int GetMonitorsXRandR15(Display* dpy, Window w, int wx, int wy,
+                               Monitor* out_monitors, size_t* out_num_monitors,
+                               size_t max_monitors) {
   if (!have_xrandr15_ext) {
     return 0;
   }
@@ -185,10 +185,10 @@ static int GetMonitorsXRandR15(Display* dpy, Window w, int wx, int wy, int ww,
   int i;
   for (i = 0; i < num_rrmonitors; ++i) {
     XRRMonitorInfo* info = &rrmonitors[i];
-    int x = CLAMP(info->x, wx, wx + ww) - wx;
-    int y = CLAMP(info->y, wy, wy + wh) - wy;
-    int w = CLAMP(info->x + info->width, wx + x, wx + ww) - (wx + x);
-    int h = CLAMP(info->y + info->height, wy + y, wy + wh) - (wy + y);
+    int x = info->x - wx;
+    int y = info->y - wy;
+    int w = info->x + info->width - (wx + x);
+    int h = info->y + info->height - (wy + y);
     AddMonitor(out_monitors, out_num_monitors, max_monitors, x, y, w, h);
   }
   XRRFreeMonitors(rrmonitors);
@@ -215,14 +215,14 @@ static int GetMonitorsXRandR(Display* dpy, Window w,
   }
 
 #ifdef HAVE_XRANDR15_EXT
-  if (GetMonitorsXRandR15(dpy, w, wx, wy, xwa->width, xwa->height, out_monitors,
-                          out_num_monitors, max_monitors)) {
+  if (GetMonitorsXRandR15(dpy, w, wx, wy, out_monitors, out_num_monitors,
+                          max_monitors)) {
     return 1;
   }
 #endif
 
-  return GetMonitorsXRandR12(dpy, w, wx, wy, xwa->width, xwa->height,
-                             out_monitors, out_num_monitors, max_monitors);
+  return GetMonitorsXRandR12(dpy, w, wx, wy, out_monitors, out_num_monitors,
+                             max_monitors);
 }
 #endif
 


### PR DESCRIPTION
First step towards a more interactive unlock experience.
Moving auth to its own window has a few benefits:
- Saver is never stopped, so information leakage is less likely (saver typically draws full screen content several times a second)
- Auth can now move the window around, e.g. in response to mouse events. It already has all monitor information, so it could mimic traditional lockers that only show the prompt on the active monitor.