### PR TITLE
Add basic support for playing sounds during the auth flow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ Options to XSecureLock can be passed by environment variables:
     that displays the authentication prompt).
 *   `XSECURELOCK_AUTHPROTO`: specifies the desired authentication protocol
     module (the part that talks to the system).
+*   `XSECURELOCK_AUTH_SOUNDS`: specifies whether to play sounds during
+    authentication to indicate status. Sounds are defined as follows:
+    *   Medium-pitch ascending: prompt for user input.
+    *   Medium-pitch constant: an info message was displayed.
+    *   Low-pitch descending: an error message was displayed.
+    *   High-pitch ascending: authentication successful.
 *   `XSECURELOCK_AUTH_TIMEOUT`: specifies the time (in seconds) to wait for
     response to a prompt by `auth_x11` before giving up and reverting to
     the screen saver.

--- a/README.md
+++ b/README.md
@@ -218,10 +218,10 @@ Options to XSecureLock can be passed by environment variables:
     module (the part that talks to the system).
 *   `XSECURELOCK_AUTH_SOUNDS`: specifies whether to play sounds during
     authentication to indicate status. Sounds are defined as follows:
-    *   Medium-pitch ascending: prompt for user input.
-    *   Medium-pitch constant: an info message was displayed.
+    *   High-pitch ascending: prompt for user input.
+    *   High-pitch constant: an info message was displayed.
     *   Low-pitch descending: an error message was displayed.
-    *   High-pitch ascending: authentication successful.
+    *   Medium-pitch ascending: authentication successful.
 *   `XSECURELOCK_AUTH_TIMEOUT`: specifies the time (in seconds) to wait for
     response to a prompt by `auth_x11` before giving up and reverting to
     the screen saver.

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -163,10 +163,10 @@ enum Sound { SOUND_PROMPT, SOUND_INFO, SOUND_ERROR, SOUND_SUCCESS };
 #define NOTE_B4 494
 #define NOTE_E5 659
 int sounds[][2] = {
-    /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},
-    /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},
-    /* SOUND_ERROR=   */ {NOTE_A3, NOTE_DS3},
-    /* SOUND_SUCCESS= */ {NOTE_DS4, NOTE_E4},
+    /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},   // D|T T
+    /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},   // T 2x
+    /* SOUND_ERROR=   */ {NOTE_A3, NOTE_DS3},  // D7 2x
+    /* SOUND_SUCCESS= */ {NOTE_DS4, NOTE_E4},  // D T
 };
 #define SOUND_SLEEP_MS 125
 #define SOUND_TONE_MS 100

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -210,6 +210,8 @@ void PlaySound(Display *display, enum Sound snd) {
                          &control);
 
   XFlush(display);
+
+  nanosleep(&sleeptime, NULL);
 }
 
 /*! \brief Switch to the next keyboard layout.

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -156,8 +156,8 @@ int have_xkb_ext;
 
 enum Sound { SOUND_PROMPT, SOUND_INFO, SOUND_ERROR, SOUND_SUCCESS };
 
-#define NOTE_E3 165
-#define NOTE_BF3 233
+#define NOTE_DS3 156
+#define NOTE_A3 220
 #define NOTE_DS4 311
 #define NOTE_E4 330
 #define NOTE_B4 494
@@ -165,7 +165,7 @@ enum Sound { SOUND_PROMPT, SOUND_INFO, SOUND_ERROR, SOUND_SUCCESS };
 int sounds[][2] = {
     /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},
     /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},
-    /* SOUND_ERROR=   */ {NOTE_BF3, NOTE_E3},
+    /* SOUND_ERROR=   */ {NOTE_A3, NOTE_DS3},
     /* SOUND_SUCCESS= */ {NOTE_DS4, NOTE_E4},
 };
 #define SOUND_SLEEP_MS 125

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -157,16 +157,16 @@ int have_xkb_ext;
 enum Sound { SOUND_PROMPT, SOUND_INFO, SOUND_ERROR, SOUND_SUCCESS };
 
 #define NOTE_E3 165
-#define NOTE_BB3 233
+#define NOTE_BF3 233
+#define NOTE_DS4 311
+#define NOTE_E4 330
 #define NOTE_B4 494
 #define NOTE_E5 659
-#define NOTE_B5 988
-#define NOTE_E6 1319
 int sounds[][2] = {
     /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},
     /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},
-    /* SOUND_ERROR=   */ {NOTE_BB3, NOTE_E3},
-    /* SOUND_SUCCESS= */ {NOTE_B5, NOTE_E6},
+    /* SOUND_ERROR=   */ {NOTE_BF3, NOTE_E3},
+    /* SOUND_SUCCESS= */ {NOTE_DS4, NOTE_E4},
 };
 #define SOUND_SLEEP_MS 125
 #define SOUND_TONE_MS 100

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -163,10 +163,10 @@ enum Sound { SOUND_PROMPT, SOUND_INFO, SOUND_ERROR, SOUND_SUCCESS };
 #define NOTE_B4 494
 #define NOTE_E5 659
 int sounds[][2] = {
-    /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},   // D|T T
-    /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},   // T 2x
-    /* SOUND_ERROR=   */ {NOTE_A3, NOTE_DS3},  // D7 2x
-    /* SOUND_SUCCESS= */ {NOTE_DS4, NOTE_E4},  // D T
+    /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},   // V|I I
+    /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},   // I 2x
+    /* SOUND_ERROR=   */ {NOTE_A3, NOTE_DS3},  // V7 2x
+    /* SOUND_SUCCESS= */ {NOTE_DS4, NOTE_E4},  // V I
 };
 #define SOUND_SLEEP_MS 125
 #define SOUND_TONE_MS 100

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -156,17 +156,17 @@ int have_xkb_ext;
 
 enum Sound { SOUND_PROMPT, SOUND_INFO, SOUND_ERROR, SOUND_SUCCESS };
 
-#define NOTE_C3 131
-#define NOTE_FS3 185
-#define NOTE_G3 196
-#define NOTE_C4 261
-#define NOTE_G4 392
-#define NOTE_C5 523
+#define NOTE_E3 165
+#define NOTE_BB3 233
+#define NOTE_B4 494
+#define NOTE_E5 659
+#define NOTE_B5 988
+#define NOTE_E6 1319
 int sounds[][2] = {
-    /* SOUND_PROMPT=  */ {NOTE_G3, NOTE_C4},
-    /* SOUND_INFO=    */ {NOTE_C4, NOTE_C4},
-    /* SOUND_ERROR=   */ {NOTE_FS3, NOTE_C3},
-    /* SOUND_SUCCESS= */ {NOTE_G4, NOTE_C5},
+    /* SOUND_PROMPT=  */ {NOTE_B4, NOTE_E5},
+    /* SOUND_INFO=    */ {NOTE_E5, NOTE_E5},
+    /* SOUND_ERROR=   */ {NOTE_BB3, NOTE_E3},
+    /* SOUND_SUCCESS= */ {NOTE_B5, NOTE_E6},
 };
 #define SOUND_SLEEP_MS 125
 #define SOUND_TONE_MS 100


### PR DESCRIPTION
Use XSECURELOCK_AUTH_SOUNDS=1 to turn them off. Requires a working X11
bell (usually provided on Linux by the pcspkr kernel module).