### PR TITLE
Fixed signal race in SIGTERM handler.

### DIFF
--- a/main.c
+++ b/main.c
@@ -855,7 +855,7 @@ int main(int argc, char **argv) {
     LogErrno("sigaction(SIGCHLD)");
   }
   sa.sa_flags = SA_RESETHAND;      // It re-raises to suicide.
-  sa.sa_handler = handle_sigterm;  // To iniate clean program shutdown.
+  sa.sa_handler = handle_sigterm;  // To initiate clean program shutdown.
   if (sigaction(SIGTERM, &sa, NULL) != 0) {
     LogErrno("sigaction(SIGTERM)");
   }


### PR DESCRIPTION
xsecurelock is prone to an unlikely signal race during shutdown:

- The main process watches its children by calling waitpid() with
  a stored child pid. It checks if child process terminated. If it did,
  the calling function will eventually set the stored child pid to 0.
- The signal handler for SIGTERM will terminate child processes
  by sending a SIGTERM. For this it iterates through an array with
  child pids and sends the signal if the stored pid is not 0.

If the main processes just called waitpid() and the signal handler
steps in, it is possible that the PID is already allocated by
another process execution, which will lead xsecurelock to send a
SIGTERM signal to a foreign process.

On regular Linux systems it takes a full cycle of the PID space,
but on OpenBSD with random PIDs this is "more likely" but still
very unlikely.

From my point of view it is no security issue anyway. I just prefer
clean signal handlers without any side-effects.

My patch changes SIGTERM handling by only setting a flag. The main
select-loop which unblocks WATCH_CHILDREN_HZ (10) times per second
will check the flag and terminate xsecurelock's processes in the
main process -- without having to worry about signal-safety. IMHO
this time delay is acceptable, especially since SIGTERM interrupts
a blocking select() call.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>