### PR TITLE
Show auth in a box on top of the saver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,6 +137,7 @@ auth_x11_SOURCES = \
 	logging.c logging.h \
 	mlock_page.h \
 	wait_pgrp.c wait_pgrp.h \
+	wm_properties.c wm_properties.h \
 	xscreensaver_api.c xscreensaver_api.h
 auth_x11_CPPFLAGS = $(macros) $(XFT_CFLAGS)
 auth_x11_LDADD = $(XFT_LIBS)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ Options to XSecureLock can be passed by environment variables:
     hostname, 1 for showing the short form, and 2 for showing the long form.
 *   `XSECURELOCK_SHOW_USERNAME`: whether to show the username on the login
     screen of `auth_x11`.
+*   `XSECURELOCK_SINGLE_AUTH_WINDOW`: whether to show only a single auth window
+    from `auth_x11`, as opposed to one per screen.
 *   `XSECURELOCK_SWITCH_USER_COMMAND`: shell command to execute when `Win-O` or
     `Ctrl-Alt-O` are pressed (think "_other_ user"). Typical values could be
     `lxdm -c USER_SWITCH`, `dm-tool switch-to-greeter`, `gdmflexiserver` or

--- a/main.c
+++ b/main.c
@@ -600,12 +600,13 @@ int main(int argc, char **argv) {
   XQueryColor(display, DefaultColormap(display, DefaultScreen(display)),
               &black);
   Pixmap bg = XCreateBitmapFromData(display, root_window, "\0", 1, 1);
+  Cursor transparent_cursor =
+      XCreatePixmapCursor(display, bg, bg, &black, &black, 0, 0);
   XSetWindowAttributes coverattrs = {0};
   coverattrs.background_pixel = black.pixel;
   coverattrs.save_under = 1;
   coverattrs.override_redirect = 1;
-  coverattrs.cursor =
-      XCreatePixmapCursor(display, bg, bg, &black, &black, 0, 0);
+  coverattrs.cursor = transparent_cursor;
 
   Window parent_window = root_window;
 
@@ -800,7 +801,7 @@ int main(int argc, char **argv) {
   int last_normal_attempt = force_grab ? 1 : 0;
   for (retries = 10; retries >= 0; --retries) {
     if (AcquireGrabs(display, root_window, my_windows, n_my_windows,
-                     coverattrs.cursor,
+                     transparent_cursor,
                      /*silent=*/retries > last_normal_attempt,
                      /*force=*/retries < last_normal_attempt)) {
       break;
@@ -903,7 +904,7 @@ int main(int argc, char **argv) {
     if (need_to_reinstate_grabs) {
       need_to_reinstate_grabs = 0;
       if (!AcquireGrabs(display, root_window, my_windows, n_my_windows,
-                        coverattrs.cursor, 0, 0)) {
+                        transparent_cursor, 0, 0)) {
         Log("Critical: could not reacquire grabs. The screen is now UNLOCKED! "
             "Trying again next frame.");
         need_to_reinstate_grabs = 1;
@@ -1156,7 +1157,7 @@ int main(int argc, char **argv) {
             // launch xsecurelock while the release event releases a passive
             // grab. We still immediately try to reacquire grabs here, though.
             if (!AcquireGrabs(display, root_window, my_windows, n_my_windows,
-                              coverattrs.cursor, 0, 0)) {
+                              transparent_cursor, 0, 0)) {
               Log("Critical: could not reacquire grabs after NotifyUngrab. The "
                   "screen is now UNLOCKED! Trying again next frame.");
               need_to_reinstate_grabs = 1;
@@ -1205,7 +1206,7 @@ done:
   }
 #endif
 
-  XFreeCursor(display, coverattrs.cursor);
+  XFreeCursor(display, transparent_cursor);
   XFreePixmap(display, bg);
 
   XCloseDisplay(display);

--- a/main.c
+++ b/main.c
@@ -85,6 +85,15 @@ limitations under the License.
  */
 #undef AUTO_RAISE
 
+/*! \brief Show cursor during auth.
+ *
+ * If enabled, a mouse cursor is shown whenever the auth_window is mapped.
+ *
+ * Note that proper use of this also would require a way to forward click
+ * events to the auth helper, which doesn't exist yet.
+ */
+#undef SHOW_CURSOR_DURING_AUTH
+
 /*! \brief Exhaustive list of all mouse related X11 events.
  *
  * These will be selected for grab. It is important that this contains all
@@ -1099,10 +1108,12 @@ int main(int argc, char **argv) {
 #endif
           if (priv.ev.xmap.window == auth_window) {
             auth_window_mapped = 1;
+#ifdef SHOW_CURSOR_DURING_AUTH
             // Actually ShowCursor...
             XGrabPointer(display, root_window, False, ALL_POINTER_EVENTS,
                          GrabModeAsync, GrabModeAsync, None, default_cursor,
                          CurrentTime);
+#endif
           } else if (priv.ev.xmap.window == saver_window) {
             saver_window_mapped = 1;
           } else if (priv.ev.xmap.window == background_window) {
@@ -1120,10 +1131,12 @@ int main(int argc, char **argv) {
 #endif
           if (priv.ev.xmap.window == auth_window) {
             auth_window_mapped = 0;
+#ifdef SHOW_CURSOR_DURING_AUTH
             // Actually HideCursor...
             XGrabPointer(display, root_window, False, ALL_POINTER_EVENTS,
                          GrabModeAsync, GrabModeAsync, None, transparent_cursor,
                          CurrentTime);
+#endif
           } else if (priv.ev.xmap.window == saver_window) {
             // This should never happen, but let's handle it anyway.
             Log("Someone unmapped the saver window. Undoing that");


### PR DESCRIPTION
A long wanted feature was having and using more flexibility in the auth module - and here it is:

- auth_x11 now displays the auth dialog in a centered dialog box in the middle.
- The saver stays running.

Still a bit rough, but already quite good. Gonna test this for a few days.

Screenshot: 
![image](https://user-images.githubusercontent.com/251568/50615619-2cbf5580-0e9a-11e9-8103-9bf511da4c31.png)
