### PR TITLE
Centralized pid handling into WaitPgrp.

### DIFF
--- a/auth_child.c
+++ b/auth_child.c
@@ -99,13 +99,13 @@ int WatchAuthChild(Window w, const char *executable, int force_auth,
   if (auth_child_pid != 0) {
     // Check if auth child returned.
     int status;
-    if (WaitPgrp("auth", auth_child_pid, 0, 0, &status)) {
+    pid_t pgrpid = auth_child_pid;
+    if (WaitPgrp("auth", &auth_child_pid, 0, 0, &status)) {
       // Try taking its process group with it. Should normally not do anything.
-      KillPgrp(auth_child_pid);
+      KillPgrp(pgrpid);
 
       // Clean up.
       close(auth_child_fd);
-      auth_child_pid = 0;
 
       // Handle success; this will exit the screen lock.
       if (status == 0) {

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -1226,7 +1226,7 @@ done:
   close(requestfd[0]);
   close(responsefd[1]);
   int status;
-  if (!WaitPgrp("authproto", childpid, 1, 0, &status)) {
+  if (!WaitPgrp("authproto", &childpid, 1, 0, &status)) {
     Log("WaitPgrp returned false but we were blocking");
     abort();
   }

--- a/helpers/until_nonidle.c
+++ b/helpers/until_nonidle.c
@@ -226,10 +226,8 @@ int main(int argc, char **argv) {
       KillPgrp(childpid);
     }
     int status;
-    if (WaitPgrp("idle", childpid, !should_be_running, !should_be_running,
-                 &status)) {
-      childpid = 0;
-    }
+    WaitPgrp("idle", &childpid, !should_be_running, !should_be_running,
+                 &status);
   }
 
   // This is the point where we can exit.

--- a/main.c
+++ b/main.c
@@ -939,9 +939,7 @@ int main(int argc, char **argv) {
     // Take care of zombies.
     if (notify_command_pid != 0) {
       int status;
-      if (WaitPgrp("notify", notify_command_pid, 0, 0, &status)) {
-        notify_command_pid = 0;
-      }
+      WaitPgrp("notify", &notify_command_pid, 0, 0, &status);
       // Otherwise, we're still alive. Re-check next time.
     }
 

--- a/saver_child.c
+++ b/saver_child.c
@@ -52,16 +52,14 @@ void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
     }
 
     int status;
-    if (WaitPgrp("saver", saver_child_pid[index], !should_be_running,
+    pid_t pgrpid = saver_child_pid[index];
+    if (WaitPgrp("saver", &saver_child_pid[index], !should_be_running,
                  !should_be_running, &status)) {
       if (should_be_running) {
         // Try taking its process group with it. Should normally not do
         // anything.
-        KillPgrp(saver_child_pid[index]);
+        KillPgrp(pgrpid);
       }
-
-      // Clean up.
-      saver_child_pid[index] = 0;
 
       // Now is the time to remove anything the child may have displayed.
       XClearWindow(dpy, w);

--- a/wait_pgrp.h
+++ b/wait_pgrp.h
@@ -24,7 +24,7 @@ limitations under the License.
 #define WAIT_NONPOSITIVE_SIGNAL (INT_MIN + 1)
 
 int KillPgrp(pid_t pid);
-int WaitPgrp(const char *name, pid_t pid, int do_block, int already_killed,
+int WaitPgrp(const char *name, pid_t *pid, int do_block, int already_killed,
              int *exit_status);
 
 #endif


### PR DESCRIPTION
To be able to create a critical section in WaitPgrp to protect
against signal races the pid handling has been moved into
WaitPgrp.

If a child process dies, its pid is set to 0 directly in WaitPgrp
which means that a pointer has to be supplied when calling the function.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>