### PR TITLE
Use explicit_bzero for password data.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ xsecurelock_SOURCES = \
 	main.c \
 	saver_child.c saver_child.h \
 	unmap_all.c unmap_all.h \
+	util.c \
 	version.c version.h \
 	wait_pgrp.c wait_pgrp.h \
 	wm_properties.c wm_properties.h \

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([])],
                [AC_MSG_RESULT([no])
                 LDFLAGS=$saved_LDFLAGS])
 
+AC_CHECK_FUNCS([explicit_bzero])
 AC_CHECK_HEADER(X11/Xlib.h,
                 [], [AC_ERROR([X includes not found.])])
 AC_CHECK_LIB(X11, XOpenDisplay,

--- a/main.c
+++ b/main.c
@@ -58,6 +58,7 @@ limitations under the License.
 #include "mlock_page.h"     // for MLOCK_PAGE
 #include "saver_child.h"    // for WatchSaverChild, KillAllSaver...
 #include "unmap_all.h"      // for ClearUnmapAllWindowsState
+#include "util.h"           // for explicit_bzero
 #include "version.h"        // for git_version
 #include "wait_pgrp.h"      // for WaitPgrp
 #include "wm_properties.h"  // for SetWMProperties
@@ -105,6 +106,17 @@ limitations under the License.
    Button2MotionMask | Button3MotionMask | Button4MotionMask |               \
    Button5MotionMask | ButtonMotionMask)
 
+//! Private (possibly containing information about the user's password) data.
+//  This data is locked to RAM using mlock() to avoid leakage to disk via swap.
+struct {
+  // The received X event.
+  XEvent ev;
+  // The decoded key press.
+  char buf[16];
+  KeySym keysym;
+  // The length of the data in buf.
+  int len;
+} priv;
 //! The name of the auth child to execute, relative to HELPER_PATH.
 const char *auth_executable;
 //! The name of the saver child to execute, relative to HELPER_PATH.
@@ -130,6 +142,7 @@ pid_t notify_command_pid = 0;
 static void HandleSIGTERM(int signo) {
   KillAllSaverChildrenSigHandler();  // Dirty, but quick.
   KillAuthChildSigHandler();         // More dirty.
+  explicit_bzero(&priv, sizeof(priv));
   raise(signo);
 }
 
@@ -840,17 +853,6 @@ int main(int argc, char **argv) {
   }
 #endif
 
-  // Private (possibly containing information about the user's password) data.
-  // This data is locked to RAM using mlock() to avoid leakage to disk via swap.
-  struct {
-    // The received X event.
-    XEvent ev;
-    // The decoded key press.
-    char buf[16];
-    KeySym keysym;
-    // The length of the data in buf.
-    int len;
-  } priv;
   if (MLOCK_PAGE(&priv, sizeof(priv)) < 0) {
     LogErrno("mlock");
     return 1;
@@ -1119,7 +1121,7 @@ int main(int argc, char **argv) {
               do_wake_up ? WakeUp(display, auth_window, saver_window, priv.buf)
                          : 0;
           // Clear out keypress data immediately.
-          memset(&priv, 0, sizeof(priv));
+          explicit_bzero(&priv, sizeof(priv));
           if (authenticated) {
             goto done;
           }
@@ -1242,7 +1244,7 @@ int main(int argc, char **argv) {
 
 done:
   // Wipe the password.
-  memset(&priv, 0, sizeof(priv));
+  explicit_bzero(&priv, sizeof(priv));
 
   // Free our resources, and exit.
   XDestroyWindow(display, auth_window);

--- a/util.c
+++ b/util.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * An earlier version of this file was originally released into the public
+ * domain by its authors. It has been modified to make the code compile and
+ * link as part of the Google Authenticator project. These changes are
+ * copyrighted by Google Inc. and released under the Apache License,
+ * Version 2.0.
+ *
+ * The previous authors' terms are included below:
+ */
+
+/*****************************************************************************
+ *
+ * File:    util.c
+ *
+ * Purpose: Collection of cross file utility functions.
+ *
+ * This code is in the public domain
+ *
+ *****************************************************************************
+ */
+
+#include <string.h>
+
+#ifndef HAVE_EXPLICIT_BZERO
+void
+explicit_bzero(void *s, size_t len)
+{
+  memset(s, '\0', len);
+  asm volatile ("":::"memory");
+}
+#endif

--- a/util.h
+++ b/util.h
@@ -1,0 +1,19 @@
+// util header file
+//
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HAVE_EXPLICIT_BZERO
+void explicit_bzero(void *s, size_t len);
+#endif


### PR DESCRIPTION
The C standard does not guarantee that memset won't be optimized away by
a compiler, which means that memset for password data is not safe.

Also clear password data in signal handler for SIGTERM, otherwise it
could happen that password data is left in memory that way.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>