### PR TITLE
Password prompt choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,14 @@ Options to XSecureLock can be passed by environment variables:
     *   `cursor`: shows a cursor that jumps around on each key press.
     *   `asterisks`: shows asterisks, like classic password prompts. This is less
         secure because password length is visible.
-    *   `hidden`: completely hides the password, and there's no feedback for keypresses.
+    *   `hidden`: completely hides the password, and there's no feedback for
+        keypresses.
     *   `disco`: shows dancers, which dance around on each key press.
+    *   `emoji`: shows an emoji, changing which one on each key press.
+        (Requires using an emoji-supporting font)
+    *   `emoticon`: shows an ascii emoticon, changing which one on each key press.
+    *   `kaomoji`: shows a kaomoji (Japanese emoticon), changing which one on each
+        key press.
 *   `XSECURELOCK_SAVER`: specifies the desired screen saver module.
 *   `XSECURELOCK_SHOW_DATETIME`: whether to show local date and time on the
     login. Disabled by default.

--- a/README.md
+++ b/README.md
@@ -311,16 +311,47 @@ Options to XSecureLock can be passed by environment variables:
     that name in `/etc/pam.d`.
 *   `XSECURELOCK_PASSWORD_PROMPT`: Choose password prompt mode:
     *   `cursor`: shows a cursor that jumps around on each key press.
+
+            ________|_______________________
+            ___________________|____________
+
     *   `asterisks`: shows asterisks, like classic password prompts. This is less
         secure because password length is visible.
+
+            ***_
+            *******_
+
     *   `hidden`: completely hides the password, and there's no feedback for
         keypresses.
+
+        ```
+        ```
+
     *   `disco`: shows dancers, which dance around on each key press.
+
+            ┏(･o･)┛ ♪ ┗(･o･)┓ ♪ ┏(･o･)┛ ♪ ┗(･o･)┓ ♪ ┏(･o･)┛
+            ┗(･o･)┓ ♪ ┏(･o･)┛ ♪ ┏(･o･)┛ ♪ ┏(･o･)┛ ♪ ┏(･o･)┛
+
     *   `emoji`: shows an emoji, changing which one on each key press.
         (Requires using an emoji-supporting font)
+
+            👍
+            🎶
+            💕
+
     *   `emoticon`: shows an ascii emoticon, changing which one on each key press.
+
+            :-O
+            d-X
+            X-\
+
     *   `kaomoji`: shows a kaomoji (Japanese emoticon), changing which one on each
         key press.
+
+            (͡°͜ʖ͡°)
+            (＾ｕ＾)
+            ¯\_(ツ)_/¯
+
 *   `XSECURELOCK_SAVER`: specifies the desired screen saver module.
 *   `XSECURELOCK_SHOW_DATETIME`: whether to show local date and time on the
     login. Disabled by default.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Options to XSecureLock can be passed by environment variables:
 *   `XSECURELOCK_PARANOID_PASSWORD`: make `auth_x11` hide the password
     length.
 *   `XSECURELOCK_DISCO_PASSWORD`: implies `XSECURELOCK_PARANOID_PASSWORD`; make `auth_x11` replace the password prompts with disco dancers.
+*   `XSECURELOCK_HIDE_PASSWORD_COMPLETELY`: implies `XSECURELOCK_PARANOID_PASSWORD`; make `auth_x11` completely hide the password and show no prompt.
 *   `XSECURELOCK_SAVER`: specifies the desired screen saver module.
 *   `XSECURELOCK_SHOW_DATETIME`: whether to show local date and time on the
     login. Disabled by default.

--- a/README.md
+++ b/README.md
@@ -309,9 +309,6 @@ Options to XSecureLock can be passed by environment variables:
     and fall back to XRandR 1.2. Not recommended.
 *   `XSECURELOCK_PAM_SERVICE`: pam service name. You should have a file with
     that name in `/etc/pam.d`.
-*   `XSECURELOCK_PARANOID_PASSWORD`: (deprecated) makes `auth_x11` hide the
-    password length. Use `XSECURELOCK_PASSWORD_PROMPT` instead. (`1` translates
-    to `cursor`; `0` translates to asterisks)
 *   `XSECURELOCK_PASSWORD_PROMPT`: Choose password prompt mode:
     *   `cursor`: shows a cursor that jumps around on each key press.
     *   `asterisks`: shows asterisks, like classic password prompts. This is less

--- a/README.md
+++ b/README.md
@@ -309,10 +309,15 @@ Options to XSecureLock can be passed by environment variables:
     and fall back to XRandR 1.2. Not recommended.
 *   `XSECURELOCK_PAM_SERVICE`: pam service name. You should have a file with
     that name in `/etc/pam.d`.
-*   `XSECURELOCK_PARANOID_PASSWORD`: make `auth_x11` hide the password
-    length.
-*   `XSECURELOCK_DISCO_PASSWORD`: implies `XSECURELOCK_PARANOID_PASSWORD`; make `auth_x11` replace the password prompts with disco dancers.
-*   `XSECURELOCK_HIDE_PASSWORD_COMPLETELY`: implies `XSECURELOCK_PARANOID_PASSWORD`; make `auth_x11` completely hide the password and show no prompt.
+*   `XSECURELOCK_PARANOID_PASSWORD`: (deprecated) makes `auth_x11` hide the
+    password length. Use `XSECURELOCK_PASSWORD_PROMPT` instead. (`1` translates
+    to `cursor`; `0` translates to asterisks)
+*   `XSECURELOCK_PASSWORD_PROMPT`: Choose password prompt mode:
+    *   `cursor`: shows a cursor that jumps around on each key press.
+    *   `asterisks`: shows asterisks, like classic password prompts. This is less
+        secure because password length is visible.
+    *   `hidden`: completely hides the password, and there's no feedback for keypresses.
+    *   `disco`: shows dancers, which dance around on each key press.
 *   `XSECURELOCK_SAVER`: specifies the desired screen saver module.
 *   `XSECURELOCK_SHOW_DATETIME`: whether to show local date and time on the
     login. Disabled by default.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Options to XSecureLock can be passed by environment variables:
     that name in `/etc/pam.d`.
 *   `XSECURELOCK_PARANOID_PASSWORD`: make `auth_x11` hide the password
     length.
+*   `XSECURELOCK_DISCO_PASSWORD`: implies `XSECURELOCK_PARANOID_PASSWORD`; make `auth_x11` replace the password prompts with disco dancers.
 *   `XSECURELOCK_SAVER`: specifies the desired screen saver module.
 *   `XSECURELOCK_SHOW_DATETIME`: whether to show local date and time on the
     login. Disabled by default.

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -963,7 +963,7 @@ int Prompt(const char *msg, char **response, int echo) {
       priv.displaylen = stride * DISCO_PASSWORD_DANCERS * strlen(disco_dancers[0]) + strlen(disco_combiner);
 
       for (size_t i = 0, bit = 1; i < DISCO_PASSWORD_DANCERS; i++, bit <<= 1) {
-        char *dancer = disco_dancers[priv.displaymarker & bit ? 1 : 0];
+        const char *dancer = disco_dancers[priv.displaymarker & bit ? 1 : 0];
         memcpy(priv.displaybuf + i * stride, disco_combiner, combiner_length);
         memcpy(priv.displaybuf + i * stride + combiner_length, dancer, dancer_length);
       }

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -48,6 +48,12 @@ limitations under the License.
 #include "authproto.h"            // for WritePacket, ReadPacket, PTYPE_R...
 #include "monitors.h"             // for Monitor, GetMonitors, IsMonitorC...
 
+#if __STDC_VERSION__ >= 201112L
+#define ASSERT(state, message) _Static_assert(state, message)
+#else
+#define ASSERT(state, message)
+#endif
+
 //! Number of args.
 int argc;
 
@@ -132,7 +138,7 @@ const char * emojis[] = {
   "\U0001f440", "\U0001f494", "\U0001f60e", "\U0001f3b6",
   "\U0001f499", "\U0001f49c", "\U0001f64c", "\U0001f633",
 };
-_Static_assert(sizeof(emojis) / sizeof(*emojis) == PARANOID_PASSWORD_LENGTH, "Emojis array size must be equal to PARANOID_PASSWORD_LENGTH");
+ASSERT(sizeof(emojis) / sizeof(*emojis) == PARANOID_PASSWORD_LENGTH, "Emojis array size must be equal to PARANOID_PASSWORD_LENGTH");
 
 // Emoticons to display in emoji mode. The length of the array must be equal to PARANOID_PASSWORD_LENGTH.
 // The first item is always display in an empty prompt (before typing in the password)
@@ -146,7 +152,7 @@ const char * emoticons[] = {
   ":'-)", ":-S", ":-D", ":-#",
   "(-':", "S-:", "D-:", "#-:",
 };
-_Static_assert(sizeof(emoticons) / sizeof(*emoticons) == PARANOID_PASSWORD_LENGTH, "Emoticons array size must be equal to PARANOID_PASSWORD_LENGTH");
+ASSERT(sizeof(emoticons) / sizeof(*emoticons) == PARANOID_PASSWORD_LENGTH, "Emoticons array size must be equal to PARANOID_PASSWORD_LENGTH");
 
 // Kaomojis to display in kaomoji mode. The length of the array must be equal to PARANOID_PASSWORD_LENGTH.
 // The first item is always display in an empty prompt (before typing in the password)
@@ -160,7 +166,7 @@ const char * kaomojis[] = {
   "¯\\_(ツ)_/¯", "(^0_0^)", "(☞ﾟ∀ﾟ)☞", "(-■_■)",
   "(┛ಠ_ಠ)┛彡┻━┻", "┬─┬ノ(º_ºノ)", "(˘³˘)♥", "❤(◍•ᴗ•◍)",
 };
-_Static_assert(sizeof(kaomojis) / sizeof(*kaomojis) == PARANOID_PASSWORD_LENGTH, "Kaomojis array size must be equal to PARANOID_PASSWORD_LENGTH");
+ASSERT(sizeof(kaomojis) / sizeof(*kaomojis) == PARANOID_PASSWORD_LENGTH, "Kaomojis array size must be equal to PARANOID_PASSWORD_LENGTH");
 
 //! If set, we can start a new login session.
 int have_switch_user_command;

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -1078,7 +1078,7 @@ int Prompt(const char *msg, char **response, int echo) {
         }
 
         case PASSWORD_PROMPT_EMOJI: {
-          ShowFromArray(emojis, priv.displaymarker, &(priv.displaybuf), &priv.displaylen);
+          ShowFromArray(emojis, priv.displaymarker, &priv.displaybuf, &priv.displaylen);
           break;
         }
 

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -953,7 +953,7 @@ int BumpDisplayMarker(int pos) {
 //! The size of the buffer to use for display, with space for cursor and NUL.
 #define DISPLAYBUF_SIZE (PWBUF_SIZE + 2)
 
-void showFromArray(const char **array, size_t displaymarker, char (*displaybuf)[], size_t *displaylen) {
+void ShowFromArray(const char **array, size_t displaymarker, char (*displaybuf)[], size_t *displaylen) {
   const char *selection = array[displaymarker];
   strcpy(*displaybuf, selection);
   *displaylen = strlen(selection);
@@ -1078,17 +1078,17 @@ int Prompt(const char *msg, char **response, int echo) {
         }
 
         case PASSWORD_PROMPT_EMOJI: {
-          showFromArray(emojis, priv.displaymarker, &(priv.displaybuf), &priv.displaylen);
+          ShowFromArray(emojis, priv.displaymarker, &(priv.displaybuf), &priv.displaylen);
           break;
         }
 
         case PASSWORD_PROMPT_EMOTICON: {
-          showFromArray(emoticons, priv.displaymarker, &priv.displaybuf, &priv.displaylen);
+          ShowFromArray(emoticons, priv.displaymarker, &priv.displaybuf, &priv.displaylen);
           break;
         }
 
         case PASSWORD_PROMPT_KAOMOJI: {
-          showFromArray(kaomojis, priv.displaymarker, &priv.displaybuf, &priv.displaylen);
+          ShowFromArray(kaomojis, priv.displaymarker, &priv.displaybuf, &priv.displaylen);
           break;
         }
 

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -1459,7 +1459,7 @@ int main(int argc_local, char **argv_local) {
   prompt_timeout = GetIntSetting("XSECURELOCK_AUTH_TIMEOUT", 5 * 60);
   show_username = GetIntSetting("XSECURELOCK_SHOW_USERNAME", 1);
   show_hostname = GetIntSetting("XSECURELOCK_SHOW_HOSTNAME", 1);
-  paranoid_password_flag = GetIntSetting("XSECURELOCK_PARANOID_PASSWORD", 1);
+  paranoid_password_flag = GetIntSetting("XSECURELOCK_" /* REMOVE IN v2 */ "PARANOID_PASSWORD", 1);
   password_prompt_flag = GetStringSetting("XSECURELOCK_PASSWORD_PROMPT", "");
   show_datetime = GetIntSetting("XSECURELOCK_SHOW_DATETIME", 0);
   datetime_format = GetStringSetting("XSECURELOCK_DATETIME_FORMAT", "%c");

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -70,7 +70,7 @@ int prompt_timeout;
 #define PARANOID_PASSWORD_LENGTH (1 << DISCO_PASSWORD_DANCERS)
 
 //! Minimum distance the cursor shall move on keypress.
-#define PARANOID_PASSWORD_MIN_CHANGE 5
+#define PARANOID_PASSWORD_MIN_CHANGE 4
 
 //! Border of the window around the text.
 #define WINDOW_BORDER 16

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -87,12 +87,6 @@ int prompt_timeout;
 //! Extra line spacing.
 #define LINE_SPACING 4
 
-//! Deprecated flag for setting Whether password display should hide the length.
-int paranoid_password_flag;
-
-//! Updated flag for password display choice
-const char * password_prompt_flag;
-
 //! Actual password prompt selected
 enum PasswordPrompt {
   PASSWORD_PROMPT_CURSOR,
@@ -1456,6 +1450,11 @@ int main(int argc_local, char **argv_local) {
     y_offset = rand() % (2 * burnin_mitigation_max_offset + 1) -
                burnin_mitigation_max_offset;
   }
+
+  //! Deprecated flag for setting whether password display should hide the length.
+  int paranoid_password_flag;
+  //! Updated flag for password display choice
+  const char * password_prompt_flag;
 
   // If requested, mitigate burn-in even more by moving the auth prompt while
   // displayed. I bet many will find this annoying though.

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -129,14 +129,14 @@ const char * disco_dancers[] = {
 // List taken from the top items in http://emojitracker.com/
 // The first item is always display in an empty prompt (before typing in the password)
 const char * emojis[] = {
-  "_____", "\U0001f602", "\U00002764", "\U0000267b",
-  "\U0001f60d", "\U00002665", "\U0001f62d", "\U0001f60a",
-  "\U0001f612", "\U0001f495", "\U0001f618", "\U0001f629",
-  "\U0000263a", "\U0001f44c", "\U0001f614", "\U0001f601",
-  "\U0001f60f", "\U0001f609", "\U0001f44d", "\U00002b05",
-  "\U0001f605", "\U0001f64f", "\U0001f60c", "\U0001f622",
-  "\U0001f440", "\U0001f494", "\U0001f60e", "\U0001f3b6",
-  "\U0001f499", "\U0001f49c", "\U0001f64c", "\U0001f633",
+  "_____", "😂", "❤", "♻",
+  "😍", "♥", "😭", "😊",
+  "😒", "💕", "😘", "😩",
+  "☺", "👌", "😔", "😁",
+  "😏", "😉", "👍", "⬅",
+  "😅", "🙏", "😌", "😢",
+  "👀", "💔", "😎", "🎶",
+  "💙", "💜", "🙌", "😳",
 };
 ASSERT(sizeof(emojis) / sizeof(*emojis) == PARANOID_PASSWORD_LENGTH, "Emojis array size must be equal to PARANOID_PASSWORD_LENGTH");
 

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -1067,7 +1067,7 @@ int Prompt(const char *msg, char **response, int echo) {
           size_t stride = combiner_length + dancer_length;
           priv.displaylen = stride * DISCO_PASSWORD_DANCERS * strlen(disco_dancers[0]) + strlen(disco_combiner);
 
-          for (size_t i = 0, bit = 1; i < DISCO_PASSWORD_DANCERS; i++, bit <<= 1) {
+          for (size_t i = 0, bit = 1; i < DISCO_PASSWORD_DANCERS; ++i, bit <<= 1) {
             const char *dancer = disco_dancers[priv.displaymarker & bit ? 1 : 0];
             memcpy(priv.displaybuf + i * stride, disco_combiner, combiner_length);
             memcpy(priv.displaybuf + i * stride + combiner_length, dancer, dancer_length);

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -83,6 +83,9 @@ int prompt_timeout;
 //! Whether password display should hide the length.
 int paranoid_password;
 
+//! Whether the password should be completely hidden
+int hide_password_completely;
+
 //! Disco mode: instead of showing the password length or line input, show a disco ball
 int disco;
 
@@ -931,6 +934,9 @@ int Prompt(const char *msg, char **response, int echo) {
       // priv.pwlen + 2 <= sizeof(priv.displaybuf).
       priv.displaybuf[priv.displaylen] = blink_state ? ' ' : *cursor;
       priv.displaybuf[priv.displaylen + 1] = '\0';
+    } else if (hide_password_completely) {
+      priv.displaylen = 0;
+      priv.displaybuf[0] = '\0';
     } else if (disco) {
       size_t combiner_length = strlen(disco_combiner);
       size_t dancer_length = strlen(disco_dancers[0]);
@@ -1321,6 +1327,7 @@ int main(int argc_local, char **argv_local) {
   show_username = GetIntSetting("XSECURELOCK_SHOW_USERNAME", 1);
   show_hostname = GetIntSetting("XSECURELOCK_SHOW_HOSTNAME", 1);
   paranoid_password = GetIntSetting("XSECURELOCK_PARANOID_PASSWORD", 1);
+  hide_password_completely = GetIntSetting("XSECURELOCK_HIDE_PASSWORD_COMPLETELY", 0);
   disco = GetIntSetting("XSECURELOCK_DISCO_PASSWORD", 0);
   show_datetime = GetIntSetting("XSECURELOCK_SHOW_DATETIME", 0);
   datetime_format = GetStringSetting("XSECURELOCK_DATETIME_FORMAT", "%c");


### PR DESCRIPTION
This PR adds an `XSECURELOCK_PASSWORD_PROMPT` environment variable, which overrides `XSECURELOCK_PARANOID_PASSWORD` with more options.

* `cursor`: shows a cursor that jumps around on each key press.
* `asterisks`: shows asterisks, like classic password prompts. This is less secure because password length is visible.
* `hidden`: completely hides the password, and there's no feedback for keypresses.
* `disco`: shows dancers, which dance around on each key press.
* `emoji`: shows an emoji, changing which one on each key press. (Requires using an emoji-supporting font)
* `emoticon`: shows an ascii emoticon, changing which one on each key press.
* `kaomoji`: shows a kaomoji (Japanese emoticon), changing which one on each key press.

`XSECURELOCK_PARANOID_PASSWORD` is marked as deprecated in the readme, so that users would proper using `XSECURELOCK_PASSWORD_PROMPT=<choice>` instead.