### PR TITLE
Add utils to cat_authproto to build when explicit_bzero is not present

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,8 @@ noinst_PROGRAMS = cat_authproto nvidia_break_compositor get_compositor remap_all
 cat_authproto_SOURCES = \
 	logging.c logging.h \
 	helpers/authproto.c helpers/authproto.h \
-	test/cat_authproto.c
+	test/cat_authproto.c \
+	util.c util.h
 nvidia_break_compositor_SOURCES = \
 	test/nvidia_break_compositor.c
 nvidia_break_compositor_CPPFLAGS = $(macros)


### PR DESCRIPTION
This change adds `util.c` and `util.h` to `cat_authproto`. 

On a system where `explicit_bzero` is not present building fails as `util.c` and `util.h` are not present in linking stage. 