### PR TITLE
authproto_pam: call pam_setcred after success.

### DIFF
--- a/helpers/authproto_pam.c
+++ b/helpers/authproto_pam.c
@@ -223,6 +223,13 @@ int Authenticate(struct pam_conv *conv, pam_handle_t **pam) {
   }
 #endif
 
+  // Have the authentication module refresh Kerberos tickets and such
+  // if applicable.
+  int sc_status = pam_setcred(*pam, PAM_REFRESH_CRED);
+  if (sc_status != PAM_SUCCESS) {
+    Log("pam_setcred: status=%d", sc_status);
+  }
+
   return status;
 }
 


### PR DESCRIPTION
`pam_setcred` will prompt the just-succeeded PAM authentication module to refresh user's authentication tokens, such as Kerberos tickets. User will then have a fresh ticket if the previous one had expired while the screen was locked.

Tested to work with `pam_krb5` and `pam_sssd`, and appears to be a no-op as expected with `pam_unix`. For reference, `xscreensaver` has done essentially the same thing that this patch does for years.

Closes #110 