### PR TITLE
saver_multiplex: configurable background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Options to XSecureLock can be passed by environment variables:
     the screen saver.
 *   `XSECURELOCK_AUTH_WARNING_COLOR`: specifies the X11 color (see manpage of
     XParseColor) for the warning text of the auth dialog.
+*   `XSECURELOCK_BACKGROUND_COLOR`: specifies the X11 color (see manpage
+    of XParseColor) for the background of the main and saver windows.
 *   `XSECURELOCK_BLANK_TIMEOUT`: specifies the time (in seconds) before telling
     X11 to fully blank the screen; a negative value disables X11 blanking. The
     time is measured since the closing of the auth window or xsecurelock

--- a/helpers/saver_multiplex.c
+++ b/helpers/saver_multiplex.c
@@ -56,13 +56,11 @@ static void WatchSavers(void) {
 }
 
 static void SpawnSavers(Window parent, int argc, char* const* argv) {
-  XSetWindowAttributes attrs = {0};
-  attrs.background_pixel = BlackPixel(display, DefaultScreen(display));
   for (size_t i = 0; i < num_monitors; ++i) {
     windows[i] =
         XCreateWindow(display, parent, monitors[i].x, monitors[i].y,
                       monitors[i].width, monitors[i].height, 0, CopyFromParent,
-                      InputOutput, CopyFromParent, CWBackPixel, &attrs);
+                      InputOutput, CopyFromParent, 0, NULL);
     SetWMProperties(display, windows[i], "xsecurelock",
                     "saver_multiplex_screen", argc, argv);
     XMapRaised(display, windows[i]);

--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@ limitations under the License.
 #include <X11/X.h>           // for Window, None, CopyFromParent
 #include <X11/Xatom.h>       // for XA_CARDINAL, XA_ATOM
 #include <X11/Xlib.h>        // for XEvent, XMapRaised, XSelectInput
+#include <X11/Xcms.h>        // for XcmsFailure
 #include <X11/Xutil.h>       // for XLookupString
 #include <X11/cursorfont.h>  // for XC_arrow
 #include <X11/keysym.h>      // for XK_BackSpace, XK_Tab, XK_o
@@ -818,12 +819,24 @@ int main(int argc, char **argv) {
   black.pixel = BlackPixel(display, DefaultScreen(display));
   XQueryColor(display, DefaultColormap(display, DefaultScreen(display)),
               &black);
+
+  XColor xcolor_background;
+  XColor dummy;
+  int status = XAllocNamedColor(
+      display, DefaultColormap(display, DefaultScreen(display)),
+      GetStringSetting("XSECURELOCK_BACKGROUND_COLOR", "black"),
+      &xcolor_background, &dummy);
+  unsigned long background_pixel = black.pixel;
+  if (status != XcmsFailure) {
+    background_pixel = xcolor_background.pixel;
+  }
+
   Pixmap bg = XCreateBitmapFromData(display, root_window, "\0", 1, 1);
   Cursor default_cursor = XCreateFontCursor(display, XC_arrow);
   Cursor transparent_cursor =
       XCreatePixmapCursor(display, bg, bg, &black, &black, 0, 0);
   XSetWindowAttributes coverattrs = {0};
-  coverattrs.background_pixel = black.pixel;
+  coverattrs.background_pixel = background_pixel;
   coverattrs.save_under = 1;
   coverattrs.override_redirect = 1;
   coverattrs.cursor = transparent_cursor;


### PR DESCRIPTION
Hi,

This change lets you change the background color of `saver_multiplex`.
It's useful to check what really happens with dpms, when coming out of sleep, etc. Otherwise I cannot differentiate an off screen from a blank saver.

I took the color lookup code from: https://github.com/google/xsecurelock/blob/53efba4c591d33e84da1ad94ae488e8b11f52f94/helpers/auth_x11.c#L1655-L1659

Cheers,
Pierre