### PR TITLE
saver_mpv: ask mpv to loop on playlist

### DIFF
--- a/helpers/saver_mpv.in
+++ b/helpers/saver_mpv.in
@@ -29,6 +29,7 @@ while true; do
     --no-audio \
     --image-display-duration="${XSECURELOCK_IMAGE_DURATION_SECONDS}" \
     --shuffle \
+    --loop-playlist=inf \
     --playlist=- &
   # Avoid spinning if mpv exits immediately, but don't wait to restart mpv in
   # the common case.


### PR DESCRIPTION
This changes avoids switching to black between mpv invocations when we reach the end of a playlist. This is quite notable when using only one image.

I would have also proposed to use `--panscan=1.0` to fit images and videos to screen, but maybe this should be proposed as an option only?