### PR TITLE
saver_mpv: allow to set custom flags using XSECURELOCK_VIDEOS_FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ Options to XSecureLock can be passed by environment variables:
     `Ctrl-Alt-O` are pressed (think "_other_ user"). Typical values could be
     `lxdm -c USER_SWITCH`, `dm-tool switch-to-greeter`, `gdmflexiserver` or
     `kdmctl reserve`, depending on your desktop environment.
+*   `XSECURELOCK_VIDEOS_FLAGS`: flags to append when invoking mpv/mplayer with
+    `saver_mpv` or `saver_mplayer`. Defaults to empty.
 *   `XSECURELOCK_WAIT_TIME_MS`: Milliseconds to wait after dimming (and before
     locking) when above xss-lock command line is used. Should be at least as
     large as the period time set using "xset s". Also used by `wait_nonidle` to

--- a/helpers/saver_mplayer.in
+++ b/helpers/saver_mplayer.in
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 : ${XSECURELOCK_LIST_VIDEOS_COMMAND:=find ~/Videos -type f}
+: ${XSECURELOCK_VIDEOS_FLAGS:=}
 
 sh -c "$XSECURELOCK_LIST_VIDEOS_COMMAND" | shuf | head -n 256 |\
 @path_to_mplayer@ \
@@ -26,4 +27,5 @@ sh -c "$XSECURELOCK_LIST_VIDEOS_COMMAND" | shuf | head -n 256 |\
   -fixed-vo \
   -nosound \
   -shuffle \
+  ${XSECURELOCK_VIDEOS_FLAGS} \
   -playlist -

--- a/helpers/saver_mpv.in
+++ b/helpers/saver_mpv.in
@@ -16,6 +16,7 @@
 
 : ${XSECURELOCK_LIST_VIDEOS_COMMAND:=find ~/Videos -type f}
 : ${XSECURELOCK_IMAGE_DURATION_SECONDS:=1}
+: ${XSECURELOCK_VIDEOS_FLAGS:=}
 
 # Run mpv in a loop so we can quickly restart mpv in case it exits (has shown
 # the last picture/video).
@@ -30,6 +31,7 @@ while true; do
     --image-display-duration="${XSECURELOCK_IMAGE_DURATION_SECONDS}" \
     --shuffle \
     --loop-playlist=inf \
+    ${XSECURELOCK_VIDEOS_FLAGS} \
     --playlist=- &
   # Avoid spinning if mpv exits immediately, but don't wait to restart mpv in
   # the common case.


### PR DESCRIPTION
This also applies to `saver_mplayer`, hence the more generic name.

See #129.