### PR TITLE
Expose screen saver index via $XSCREENSAVER_SAVER_INDEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,8 @@ The screen saver module is a separate executable, whose name must start with
 `saver_` and be installed together with the included `auth_` modules (default
 location: `/usr/local/libexec/xsecurelock/helpers`).
 
-*   Input: none.
+*   Input: receives the 0-based index of the screen saver (remember: one saver
+    is started per display by the multiplexer) via `$XSCREENSAVER_SAVER_INDEX`.
 *   Output: it may draw on or create windows below `$XSCREENSAVER_WINDOW`.
 *   Exit condition: the saver child will receive SIGTERM when the user wishes to
     unlock the screen. It should exit promptly.

--- a/saver_child.c
+++ b/saver_child.c
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include "logging.h"           // for LogErrno, Log
 #include "wait_pgrp.h"         // for KillPgrp, WaitPgrp
-#include "xscreensaver_api.h"  // for ExportWindowID
+#include "xscreensaver_api.h"  // for ExportWindowID and ExportSaverIndex
 
 //! The PIDs of currently running saver children, or 0 if not running.
 static pid_t saver_child_pid[MAX_SAVERS] = {0};
@@ -65,6 +65,7 @@ void WatchSaverChild(Display* dpy, Window w, int index, const char* executable,
       // Child process.
       StartPgrp();
       ExportWindowID(w);
+      ExportSaverIndex(index);
 
       {
         const char* args[3] = {

--- a/xscreensaver_api.c
+++ b/xscreensaver_api.c
@@ -34,6 +34,17 @@ void ExportWindowID(Window w) {
   setenv("XSCREENSAVER_WINDOW", window_id_str, 1);
 }
 
+void ExportSaverIndex(int index) {
+  char saver_index_str[32];
+  int saver_index_len = snprintf(saver_index_str, sizeof(saver_index_str), "%llu",
+                                 (unsigned long long)index);
+  if (saver_index_len <= 0 || (size_t)saver_index_len >= sizeof(saver_index_str)) {
+    Log("Saver index doesn't fit into buffer");
+    return;
+  }
+  setenv("XSCREENSAVER_SAVER_INDEX", saver_index_str, 1);
+}
+
 Window ReadWindowID(void) {
   return GetUnsignedLongLongSetting("XSCREENSAVER_WINDOW", None);
 }

--- a/xscreensaver_api.h
+++ b/xscreensaver_api.h
@@ -27,6 +27,14 @@ limitations under the License.
  */
 void ExportWindowID(Window w);
 
+/*! \brief Export the given saver index to the environment for a saver/auth child.
+ *
+ * This simply sets $XSCREENSAVER_SAVER_INDEX.
+ *
+ * \param index The index of the saver.
+ */
+void ExportSaverIndex(int index);
+
 /*! \brief Reads the window ID to draw on from the environment.
  *
  * This simply reads $XSCREENSAVER_WINDOW.


### PR DESCRIPTION
Fixes #143.

## Example Usage

### saver_feh

```sh
#!/usr/bin/env bash

set -euo pipefail

if [ "$XSCREENSAVER_SAVER_INDEX" = "1" ]; then
  IMAGE_PATH="$XSECURELOCK_IMAGE_PATH_1"
else
  IMAGE_PATH="$XSECURELOCK_IMAGE_PATH_0"
fi

feh \
  --window-id="$XSCREENSAVER_WINDOW" \
  --xinerama-index="$XSCREENSAVER_SAVER_INDEX" \
  -F "$IMAGE_PATH
```

### Invocation

```sh
XSECURELOCK_IMAGE_PATH_0="$HOME/Pictures/left-screen.png" \
XSECURELOCK_IMAGE_PATH_1="$HOME/Pictures/right-screen.png" \
XSECURELOCK_SAVER=saver_feh \
xsecurelock
```