### PR TITLE
Add option to not kill saver when DPMS kicks in

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ Options to XSecureLock can be passed by environment variables:
 *   `XSECURELOCK_SAVER_DELAY_MS`: Milliseconds to wait after starting
     children process and before mapping windows to let children be
     ready to display and reduce the black flash.
+*   `XSECURELOCK_SAVER_STOP_ON_DPMS`: specifies if saver is stopped
+    when DPMS blanks the screen (to save power).
 *   `XSECURELOCK_XSCREENSAVER_PATH`: Location where XScreenSaver hacks are
     installed for use by `saver_xscreensaver`.
 

--- a/main.c
+++ b/main.c
@@ -152,6 +152,8 @@ const char *blank_dpms_state = "off";
 int saver_reset_on_auth_close = 0;
 //! Delay we should wait before starting mapping windows to let children run.
 int saver_delay_ms = 0;
+//! Whetever stopping saver when DPMS is running
+int saver_stop_on_dpms = 0;
 
 //! The PID of a currently running notify command, or 0 if none is running.
 pid_t notify_command_pid = 0;
@@ -441,6 +443,7 @@ void LoadDefaults() {
   saver_reset_on_auth_close =
       GetIntSetting("XSECURELOCK_SAVER_RESET_ON_AUTH_CLOSE", 0);
   saver_delay_ms = GetIntSetting("XSECURELOCK_SAVER_DELAY_MS", 0);
+  saver_stop_on_dpms = GetIntSetting("XSECURELOCK_SAVER_STOP_ON_DPMS", 1);
 }
 
 /*! \brief Parse the command line arguments, or exit in case of failure.
@@ -1171,7 +1174,7 @@ int main(int argc, char **argv) {
 
     // Make sure to shut down the saver when blanked. Saves power.
     enum WatchChildrenState requested_saver_state =
-        blanked ? WATCH_CHILDREN_SAVER_DISABLED : xss_requested_saver_state;
+      (saver_stop_on_dpms && blanked) ? WATCH_CHILDREN_SAVER_DISABLED : xss_requested_saver_state;
 
     // Now check status of our children.
     if (WatchChildren(display, auth_window, saver_window, requested_saver_state,


### PR DESCRIPTION
This is a patch embedded in #139, but as this is unlikely to be merged, I am submitting it separately. The use case is that if the screensaver takes some time to start but does not eat CPU, this may be interesting to leave it running (in my case, it starts fast, but it takes some time to display all the information on it).