### PR TITLE
Rename XSECURELOCK_SAVER_STOP_ON_DPMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,8 +443,8 @@ Options to XSecureLock can be passed by environment variables:
 *   `XSECURELOCK_SAVER_DELAY_MS`: Milliseconds to wait after starting
     children process and before mapping windows to let children be
     ready to display and reduce the black flash.
-*   `XSECURELOCK_SAVER_STOP_ON_DPMS`: specifies if saver is stopped
-    when DPMS blanks the screen (to save power).
+*   `XSECURELOCK_SAVER_STOP_ON_BLANK`: specifies if saver is stopped
+    when screen is blanked (DPMS or XSS) to save power.
 *   `XSECURELOCK_XSCREENSAVER_PATH`: Location where XScreenSaver hacks are
     installed for use by `saver_xscreensaver`.
 


### PR DESCRIPTION
The correct name should be XSECURELOCK_SAVER_STOP_ON_BLANK. We also starts children when screensaver is on, but screen is not blanked, or when screensaver is one and screen is blanked, but this option is not enabled.

I can do a separate pull request for this one-line change if you prefer. Then, I get the same behaviour than #139 by setting `XSECURELOCK_BLANK_TIMEOUT=-1`.