### PR TITLE
In `auth_x11.c`, the `CreateOrUpdatePerMonitorWindow` function has be…

### DIFF
--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -919,6 +919,10 @@ void DisplayMessage(const char *title, const char *str, int is_warning) {
     }
   }
 
+  for (size_t i = 0; i < num_windows; ++i) {
+      XClearWindow(display, windows[i]);
+  }
+
   UpdatePerMonitorWindows(per_monitor_windows_dirty, region_w, region_h,
                           x_offset, y_offset);
   per_monitor_windows_dirty = 0;
@@ -928,7 +932,8 @@ void DisplayMessage(const char *title, const char *str, int is_warning) {
     int cy = region_h / 2;
     int y = cy + to - box_h / 2;
 
-    XClearWindow(display, windows[i]);
+    //Moved out from here, calling XClearWindow after UpdatePerMonitorWindows can leave artifacts on screen
+    //XClearWindow(display, windows[i]);
 
 #ifdef DRAW_BORDER
     XDrawRectangle(display, windows[i], gcs[i],     //


### PR DESCRIPTION
…en modified:

When the updated window is smaller in size (which can be caused by, eg. changing the keyboard layout) than the previous one, artifacts (parts of the previous window) may remain on the screen. To avoid this, `XClearWindow` is now called before `UpdatePerMonitorWindows`.

An example picture is attached.
![sample](https://github.com/google/xsecurelock/assets/31699980/2d3c1d9a-63cb-4917-bcfe-037d8f11d1e0)
