### PR TITLE
Move escape so it clears the password instead of returning a bad password

### DIFF
--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -1287,6 +1287,7 @@ int Prompt(const char *msg, char **response, int echo) {
                             &priv.last_keystroke);
           break;
         }
+        case '\033':  // Escape.
         case '\001':  // Ctrl-A.
           // Clearing input line on just Ctrl-A is odd - but commonly
           // requested. In most toolkits, Ctrl-A does not immediately erase but
@@ -1307,7 +1308,6 @@ int Prompt(const char *msg, char **response, int echo) {
                             &priv.last_keystroke);
           break;
         case 0:       // Shouldn't happen.
-        case '\033':  // Escape.
           done = 1;
           break;
         case '\r':  // Return.


### PR DESCRIPTION
When I press ESC it pauses.   If I press password a few times to try to get out of it.  It locks up the computer and I can't login for 10 minutes for doing too many password attempts.  This changes it so ESC clears the password instead.  #114 