### PR TITLE
feat: Add XSECURELOCK_TOP_LEFT for top-left alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,9 @@ Options to XSecureLock can be passed by environment variables:
     screen of `auth_x11`.
 *   `XSECURELOCK_SINGLE_AUTH_WINDOW`: whether to show only a single auth window
     from `auth_x11`, as opposed to one per screen.
+*   `XSECURELOCK_TOP_LEFT`: If set to `x:y` coordinates, the authentication
+    window will be positioned at that top-left corner of the screen. Otherwise,
+    the window is centered.
 *   `XSECURELOCK_SWITCH_USER_COMMAND`: shell command to execute when `Win-O` or
     `Ctrl-Alt-O` are pressed (think "_other_ user"). Typical values could be
     `lxdm -c USER_SWITCH`, `dm-tool switch-to-greeter`, `gdmflexiserver` or

--- a/helpers/auth_x11.c
+++ b/helpers/auth_x11.c
@@ -93,6 +93,10 @@ int prompt_timeout;
 //! Extra line spacing.
 #define LINE_SPACING 4
 
+// top left pixel margins
+static int top_left_x = -1;
+static int top_left_y = -1;
+
 //! Actual password prompt selected
 enum PasswordPrompt {
   PASSWORD_PROMPT_CURSOR,
@@ -566,11 +570,27 @@ void DestroyPerMonitorWindows(size_t keep_windows) {
 void CreateOrUpdatePerMonitorWindow(size_t i, const Monitor *monitor,
                                     int region_w, int region_h, int x_offset,
                                     int y_offset) {
+  const char *top_left = GetStringSetting("XSECURELOCK_TOP_LEFT", NULL);
+  if (top_left != NULL) {
+    int x = 0, y = 0;
+    if (sscanf(top_left, "%d:%d", &x, &y) == 2) {
+      top_left_x = x;
+      top_left_y = y;
+    }
+  }
+
   // Desired box.
   int w = region_w;
   int h = region_h;
-  int x = monitor->x + (monitor->width - w) / 2 + x_offset;
-  int y = monitor->y + (monitor->height - h) / 2 + y_offset;
+  int x =
+      (top_left != NULL)
+          ? monitor->x + top_left_x + x_offset
+          : monitor->x + (monitor->width - w) / 2 + x_offset;
+  int y =
+      (top_left != NULL)
+          ? monitor->y + top_left_y + y_offset
+          : monitor->y + (monitor->height - h) / 2 + y_offset;
+
   // Clip to monitor.
   if (x < 0) {
     w += x;
@@ -923,10 +943,11 @@ void DisplayMessage(const char *title, const char *str, int is_warning) {
                           x_offset, y_offset);
   per_monitor_windows_dirty = 0;
 
+  const int is_top_left = (top_left_x != -1);
   for (size_t i = 0; i < num_windows; ++i) {
     int cx = region_w / 2;
     int cy = region_h / 2;
-    int y = cy + to - box_h / 2;
+    int y = is_top_left ? to : cy + to - box_h / 2;
 
     XClearWindow(display, windows[i]);
 
@@ -937,30 +958,33 @@ void DisplayMessage(const char *title, const char *str, int is_warning) {
 #endif
 
     if (show_datetime) {
-      DrawString(i, cx - tw_datetime / 2, y, 0, datetime, len_datetime);
-      y += th * 2;
+      const int x_pos = is_top_left ? 0 : cx - tw_datetime / 2;
+      DrawString(i, x_pos, y, 0, datetime, len_datetime);
+      y += is_top_left ? th : th * 2;
     }
 
-    DrawString(i, cx - tw_full_title / 2, y, is_warning, full_title,
-               len_full_title);
-    y += th * 2;
+    const int x_pos_title = is_top_left ? 0 : cx - tw_full_title / 2;
+    DrawString(i, x_pos_title, y, is_warning, full_title, len_full_title);
+    y += is_top_left ? th : th * 2;
 
-    DrawString(i, cx - tw_str / 2, y, is_warning, str, len_str);
+    const int x_pos_str = is_top_left ? 0 : cx - tw_str / 2;
+    DrawString(i, x_pos_str, y, is_warning, str, len_str);
     y += th;
 
-    DrawString(i, cx - tw_indicators / 2, y, indicators_warning, indicators,
+    const int x_pos_indicators = is_top_left ? 0 : cx - tw_indicators / 2;
+    DrawString(i, x_pos_indicators, y, indicators_warning, indicators,
                len_indicators);
     y += th;
 
     if (have_multiple_layouts) {
-      DrawString(i, cx - tw_switch_layout / 2, y, 0, switch_layout,
-                 len_switch_layout);
+      const int x_pos_layout = is_top_left ? 0 : cx - tw_switch_layout / 2;
+      DrawString(i, x_pos_layout, y, 0, switch_layout, len_switch_layout);
       y += th;
     }
 
     if (have_switch_user_command) {
-      DrawString(i, cx - tw_switch_user / 2, y, 0, switch_user,
-                 len_switch_user);
+      const int x_pos_user = is_top_left ? 0 : cx - tw_switch_user / 2;
+      DrawString(i, x_pos_user, y, 0, switch_user, len_switch_user);
       // y += th;
     }
   }
@@ -1025,7 +1049,8 @@ void BumpDisplayMarker(size_t pwlen, size_t *pos,
 void ShowFromArray(const char **array, size_t displaymarker, char *displaybuf,
                    size_t displaybufsize, size_t *displaylen) {
   const char *selection = array[displaymarker];
-  strncpy(displaybuf, selection, displaybufsize);
+  /* strncpy(displaybuf, selection, displaybufsize); */
+  strncpy(displaybuf, selection, displaybufsize - 1);
   displaybuf[displaybufsize - 1] = 0;
   *displaylen = strlen(selection);
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to align the authentication window to the top-left corner of the screen.

## Description

A new environment variable, `XSECURELOCK_TOP_LEFT`, has been added. When set to x:y coordinates (e.g., 10:10), it positions the authentication window at that specific top-left corner. If the variable is not set, the window remains centered, preserving the existing default behavior.

This provides users with more flexibility to customize the look and feel of the lock screen, especially for tiling window manager users or those with specific multi-monitor setups.

## Implementation Details

The following changes were made to `helpers/auth_x11.c`:

- Window Positioning: The `CreateOrUpdatePerMonitorWindow` function now checks for the `XSECURELOCK_TOP_LEFT` variable. If it's set, the function uses the provided coordinates to calculate the window's position. Otherwise, it continues to center the window on the monitor.

- Text Alignment: In the `DisplayMessage` function, the horizontal position of each line of text is now determined by whether `XSECURELOCK_TOP_LEFT` is set. If it is, the text is aligned to the left (x-coordinate 0 within the window); otherwise, it is centered.

- Line Spacing: The vertical spacing between lines of text has been adjusted. When top-left alignment is active, the spacing is reduced for a more compact appearance.

- Vertical Centering: The initial vertical position (y) of the text block is now calculated to start from the top of the window when `XSECURELOCK_TOP_LEFT` is set, removing the previous top margin that was present for centered alignment.


## Documentation

The `README.md` file has been updated to include documentation for the new `XSECURELOCK_TOP_LEFT` environment variable.

This change has been tested manually to ensure that both the new top-left alignment and the default centered alignment work as expected.

`./run-linter.sh` and `test/run-tests.sh` have been run without new errors for this edit. Some error came out but not regarding this new edit.

We are open to make any changes to make the pull request possible.